### PR TITLE
feat: add import_records tool for idempotent upsert via load()

### DIFF
--- a/mcp_server_odoo/connection_protocol.py
+++ b/mcp_server_odoo/connection_protocol.py
@@ -60,6 +60,14 @@ class OdooConnectionProtocol(Protocol):
 
     def create_bulk(self, model: str, vals_list: List[Dict[str, Any]]) -> List[int]: ...
 
+    def load_records(
+        self,
+        model: str,
+        fields: List[str],
+        data: List[List[str]],
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]: ...
+
     def write(self, model: str, ids: List[int], values: Dict[str, Any]) -> bool: ...
 
     def unlink(self, model: str, ids: List[int]) -> bool: ...

--- a/mcp_server_odoo/odoo_connection.py
+++ b/mcp_server_odoo/odoo_connection.py
@@ -999,6 +999,51 @@ class OdooConnection:
             logger.error(f"Failed to bulk create {model} records: {e}")
             raise
 
+    def load_records(
+        self,
+        model: str,
+        fields: List[str],
+        data: List[List[str]],
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Import records using Odoo's load() method with external ID support.
+
+        This wraps Odoo's native load() ORM method, which supports:
+        - Idempotent upsert via external IDs (column name 'id')
+        - Relational field resolution via external IDs (e.g., 'parent_id/id')
+        - Batch processing with per-row error reporting
+
+        Args:
+            model: Odoo model name (e.g., 'res.partner')
+            fields: List of field names. Use 'id' for external ID column.
+                    Use 'field/id' to reference related records by external ID.
+            data: List of rows, each row is a list of string values.
+                  Values must be strings (Odoo load() expects strings).
+            context: Optional context dict (e.g., {'tracking_disable': True})
+
+        Returns:
+            Dict with 'ids' (created/updated record IDs) and 'messages' (errors)
+
+        Raises:
+            OdooConnectionError: If the load operation fails
+        """
+        try:
+            with self._performance_manager.monitor.track_operation(f"load_{model}"):
+                kwargs = {}
+                if context:
+                    kwargs["context"] = context
+                result = self.execute_kw(model, "load", [fields, data], kwargs)
+                self._performance_manager.invalidate_record_cache(model)
+                logger.info(
+                    f"Loaded {len(data)} row(s) into {model}: "
+                    f"{len(result.get('ids', []))} OK, "
+                    f"{len(result.get('messages', []))} messages"
+                )
+                return result
+        except Exception as e:
+            logger.error(f"Failed to load records into {model}: {e}")
+            raise
+
     def write(self, model: str, ids: List[int], values: Dict[str, Any]) -> bool:
         """Update existing records.
 

--- a/mcp_server_odoo/odoo_json2_connection.py
+++ b/mcp_server_odoo/odoo_json2_connection.py
@@ -438,6 +438,36 @@ class OdooJSON2Connection:
         logger.info(f"Bulk created {len(result)} {model} record(s)")
         return result
 
+    def load_records(
+        self,
+        model: str,
+        fields: List[str],
+        data: List[List[str]],
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Import records using Odoo's load() method with external ID support.
+
+        Args:
+            model: Odoo model name (e.g., 'res.partner')
+            fields: List of field names. Use 'id' for external ID column.
+            data: List of rows, each row is a list of string values.
+            context: Optional context dict (e.g., {'tracking_disable': True})
+
+        Returns:
+            Dict with 'ids' (created/updated record IDs) and 'messages' (errors)
+        """
+        kwargs: Dict[str, Any] = {"fields": fields, "data": data}
+        if context:
+            kwargs["context"] = context
+        result = self._call(model, "load", **kwargs)
+        self._fields_cache.pop(model, None)
+        logger.info(
+            f"Loaded {len(data)} row(s) into {model}: "
+            f"{len(result.get('ids', []))} OK, "
+            f"{len(result.get('messages', []))} messages"
+        )
+        return result
+
     def write(self, model: str, ids: List[int], values: Dict[str, Any]) -> bool:
         """Update existing records.
 

--- a/mcp_server_odoo/schemas.py
+++ b/mcp_server_odoo/schemas.py
@@ -185,8 +185,7 @@ class ImportResult(BaseModel):
     """Result of importing records via Odoo's load() method with external ID support."""
 
     success: bool = Field(description="Whether all records were imported successfully")
-    created: int = Field(description="Number of records created")
-    updated: int = Field(description="Number of records updated")
+    imported: int = Field(description="Number of records imported (created or updated)")
     errors: List[Dict[str, Any]] = Field(
         default_factory=list,
         description="List of errors with row index and message",

--- a/mcp_server_odoo/schemas.py
+++ b/mcp_server_odoo/schemas.py
@@ -178,6 +178,27 @@ class BulkDeleteResult(BaseModel):
     message: str = Field(description="Human-readable success message")
 
 
+# --- Import (load) ---
+
+
+class ImportResult(BaseModel):
+    """Result of importing records via Odoo's load() method with external ID support."""
+
+    success: bool = Field(description="Whether all records were imported successfully")
+    created: int = Field(description="Number of records created")
+    updated: int = Field(description="Number of records updated")
+    errors: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description="List of errors with row index and message",
+    )
+    ids: List[int] = Field(
+        default_factory=list,
+        description="IDs of created/updated records",
+    )
+    model: str = Field(description="Odoo model name")
+    message: str = Field(description="Human-readable summary message")
+
+
 # --- Server Info ---
 
 

--- a/mcp_server_odoo/tools.py
+++ b/mcp_server_odoo/tools.py
@@ -32,6 +32,7 @@ from .schemas import (
     CreateResult,
     DeleteResult,
     FieldSelectionMetadata,
+    ImportResult,
     ModelsResult,
     RecordResult,
     ResourceTemplatesResult,
@@ -822,6 +823,53 @@ class OdooToolHandler:
             self._track_usage(_current_sub.get(), "delete_records")
             return BulkDeleteResult(**result)
 
+        # --- Import (load) ---
+
+        @self.app.tool(
+            title="Import Records (Upsert with External IDs)",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+        async def import_records(
+            model: str,
+            fields: List[str],
+            data: List[List[str]],
+            context: Optional[Dict[str, Any]] = None,
+        ) -> ImportResult:
+            """Import records using Odoo's native load() method with external ID support.
+
+            This is the recommended way to import data. It supports idempotent
+            upsert: if a record with the given external ID already exists, it will
+            be updated instead of duplicated. Running the same import twice
+            produces the same result.
+
+            Uses the same mechanism as Odoo's built-in CSV import.
+
+            Args:
+                model: The Odoo model name (e.g., 'res.partner')
+                fields: List of field names matching the data columns.
+                    Use 'id' for the external ID column (e.g., '__import__.partner_acme').
+                    Use 'field_name/id' to reference related records by external ID
+                    (e.g., 'parent_id/id' with value '__import__.partner_parent').
+                    Use 'field_name/.id' to reference by database ID.
+                data: List of rows, where each row is a list of string values.
+                    All values must be strings. Example:
+                    [["__import__.partner_acme", "Acme Corp", "True"]]
+                context: Optional context dict. Useful flags:
+                    - tracking_disable: True — suppress mail/activity notifications
+                    - defer_fields_computation: True — batch computed field updates
+
+            Returns:
+                Import result with counts of created/updated records and any errors.
+            """
+            result = await self._handle_import_records_tool(model, fields, data, context)
+            self._track_usage(_current_sub.get(), "import_records")
+            return ImportResult(**result)
+
     async def _handle_search_tool(
         self,
         model: str,
@@ -1436,6 +1484,91 @@ class OdooToolHandler:
             logger.error(f"Error in delete_records tool: {e}")
             sanitized_msg = ErrorSanitizer.sanitize_message(str(e))
             raise ValidationError(f"Bulk delete failed: {sanitized_msg}") from e
+
+    async def _handle_import_records_tool(
+        self,
+        model: str,
+        fields: List[str],
+        data: List[List[str]],
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Handle import_records tool request using Odoo's load() method."""
+        try:
+            connection, access_controller, sub = await self._get_user_context()
+            with perf_logger.track_operation("tool_import_records", model=model):
+                access_controller.validate_model_access(model, "create")
+                if not connection.is_authenticated:
+                    raise ValidationError("Not authenticated with Odoo")
+                if not fields:
+                    raise ValidationError("fields cannot be empty")
+                if not data:
+                    raise ValidationError("data cannot be empty")
+                if len(data) > MAX_BULK_SIZE:
+                    raise ValidationError(
+                        f"Import limited to {MAX_BULK_SIZE} rows, got {len(data)}"
+                    )
+
+                # Validate that all rows have the same number of columns as fields
+                for i, row in enumerate(data):
+                    if len(row) != len(fields):
+                        raise ValidationError(
+                            f"Row {i} has {len(row)} values but {len(fields)} fields were specified"
+                        )
+
+                # Ensure all values are strings (Odoo load() expects strings)
+                str_data = [[str(v) if v is not None else "" for v in row] for row in data]
+
+                result = connection.load_records(model, fields, str_data, context)
+
+                # Parse Odoo load() result
+                ids = result.get("ids", []) or []
+                messages = result.get("messages", []) or []
+
+                # Filter out False/None from ids (failed rows return False)
+                valid_ids = [id_ for id_ in ids if id_]
+
+                # Separate errors from warnings
+                errors = [
+                    {"row": msg.get("rows", {}).get("from", -1), "message": msg.get("message", ""), "type": msg.get("type", "error")}
+                    for msg in messages
+                    if msg.get("type") == "error"
+                ]
+
+                # Determine created vs updated counts
+                # load() doesn't distinguish, but we can check if 'id' column was provided
+                has_external_ids = "id" in fields
+                success = len(errors) == 0
+
+                # Build summary
+                if success:
+                    action = "imported (created/updated)" if has_external_ids else "created"
+                    message = f"Successfully {action} {len(valid_ids)} {model} record(s)"
+                else:
+                    message = (
+                        f"Import completed with {len(errors)} error(s). "
+                        f"{len(valid_ids)} record(s) succeeded."
+                    )
+
+                return {
+                    "success": success,
+                    "created": len(valid_ids),
+                    "updated": 0,  # load() doesn't distinguish; total count in 'created'
+                    "errors": errors,
+                    "ids": valid_ids,
+                    "model": model,
+                    "message": message,
+                }
+
+        except ValidationError:
+            raise
+        except AccessControlError as e:
+            raise ValidationError(f"Access denied: {e}") from e
+        except OdooConnectionError as e:
+            raise ValidationError(f"Connection error: {e}") from e
+        except Exception as e:
+            logger.error(f"Error in import_records tool: {e}")
+            sanitized_msg = ErrorSanitizer.sanitize_message(str(e))
+            raise ValidationError(f"Import failed: {sanitized_msg}") from e
 
 
 def register_tools(

--- a/mcp_server_odoo/tools.py
+++ b/mcp_server_odoo/tools.py
@@ -1497,6 +1497,7 @@ class OdooToolHandler:
             connection, access_controller, sub = await self._get_user_context()
             with perf_logger.track_operation("tool_import_records", model=model):
                 access_controller.validate_model_access(model, "create")
+                access_controller.validate_model_access(model, "write")
                 if not connection.is_authenticated:
                     raise ValidationError("Not authenticated with Odoo")
                 if not fields:
@@ -1515,10 +1516,19 @@ class OdooToolHandler:
                             f"Row {i} has {len(row)} values but {len(fields)} fields were specified"
                         )
 
+                # Validate context keys (prevent dangerous keys like 'su')
+                safe_context = None
+                if context:
+                    allowed_keys = {"tracking_disable", "defer_fields_computation", "lang", "tz", "no_reset_password"}
+                    unsafe_keys = set(context.keys()) - allowed_keys
+                    if unsafe_keys:
+                        raise ValidationError(f"Context contains disallowed keys: {unsafe_keys}")
+                    safe_context = context
+
                 # Ensure all values are strings (Odoo load() expects strings)
                 str_data = [[str(v) if v is not None else "" for v in row] for row in data]
 
-                result = connection.load_records(model, fields, str_data, context)
+                result = connection.load_records(model, fields, str_data, safe_context)
 
                 # Parse Odoo load() result
                 ids = result.get("ids", []) or []
@@ -1551,8 +1561,7 @@ class OdooToolHandler:
 
                 return {
                     "success": success,
-                    "created": len(valid_ids),
-                    "updated": 0,  # load() doesn't distinguish; total count in 'created'
+                    "imported": len(valid_ids),
                     "errors": errors,
                     "ids": valid_ids,
                     "model": model,


### PR DESCRIPTION
## Summary
- Adds `import_records` MCP tool wrapping Odoo's native `load()` ORM method
- Enables idempotent upsert: records with existing external IDs are updated, new ones are created
- Same mechanism as Odoo's built-in CSV import — running twice = no duplicates
- Works on both XML-RPC (Odoo 14-18) and JSON/2 (Odoo 19+)

## Changes
- `schemas.py`: `ImportResult` Pydantic model
- `odoo_connection.py`: `load_records()` method (XML-RPC path)
- `odoo_json2_connection.py`: `load_records()` method (JSON/2 path)
- `tools.py`: `import_records` tool registration + `_handle_import_records_tool` handler

## Usage example
```
import_records(
    model="res.partner",
    fields=["id", "name", "is_company"],
    data=[
        ["__import__.partner_acme", "Acme Corp", "True"],
        ["__import__.partner_globex", "Globex Inc", "True"],
    ],
    context={"tracking_disable": True}
)
```

## Test plan
- [ ] Verify tool appears in MCP tool listing
- [ ] Test create: import new records with external IDs
- [ ] Test upsert: re-import same external IDs with changed values → updates, no duplicates
- [ ] Test relational fields: import contacts with `parent_id/id` referencing partner external IDs
- [ ] Test error handling: import with invalid field names, missing required fields
- [ ] Test on XML-RPC (Odoo 17/18) and JSON/2 (Odoo 19) connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)