### PR TITLE
skills + tools: prefer find_skill, throttle binary uploads

### DIFF
--- a/mcp_server_odoo/registry.py
+++ b/mcp_server_odoo/registry.py
@@ -10,8 +10,6 @@ import time
 from dataclasses import dataclass, field
 from typing import Dict
 
-from .usage import track_event
-
 from .access_control import AccessController
 from .config import OdooConfig
 from .connection_protocol import OdooConnectionProtocol
@@ -19,6 +17,7 @@ from .exceptions import OdooConnectionError
 from .odoo_connection import OdooConnection
 from .odoo_json2_connection import OdooJSON2Connection
 from .performance import PerformanceManager
+from .usage import track_event
 from .version_detect import detect_api_version
 
 logger = logging.getLogger(__name__)
@@ -100,7 +99,11 @@ class ConnectionRegistry:
         try:
             api_version, server_version = detect_api_version(user_conn.odoo_url)
         except Exception as e:
-            track_event("connection_error", distinct_id=zitadel_sub, properties={"type": "unreachable", "url": user_conn.odoo_url})
+            track_event(
+                "connection_error",
+                distinct_id=zitadel_sub,
+                properties={"type": "unreachable", "url": user_conn.odoo_url},
+            )
             raise OdooConnectionError(
                 f"Cannot reach your Odoo server at {user_conn.odoo_url}. "
                 f"Please check that the URL is correct and the server is online. "
@@ -141,9 +144,17 @@ class ConnectionRegistry:
                 error_type = "missing_database"
             elif "Cannot reach" in error_str:
                 error_type = "unreachable"
-            track_event("connection_error", distinct_id=zitadel_sub, properties={
-                "type": error_type, "api_version": api_version, "hosting": "odoo.sh" if ".odoo.com" in user_conn.odoo_url.lower() else "self-hosted",
-            })
+            track_event(
+                "connection_error",
+                distinct_id=zitadel_sub,
+                properties={
+                    "type": error_type,
+                    "api_version": api_version,
+                    "hosting": "odoo.sh"
+                    if ".odoo.com" in user_conn.odoo_url.lower()
+                    else "self-hosted",
+                },
+            )
 
             # Build helpful troubleshooting message
             details = [

--- a/mcp_server_odoo/schemas.py
+++ b/mcp_server_odoo/schemas.py
@@ -207,7 +207,9 @@ class BinaryFieldResult(BaseModel):
     success: bool = Field(description="Whether the field was written successfully")
     model: str = Field(description="Odoo model name")
     record_id: int = Field(description="Record ID that was updated")
-    field: str = Field(description="Binary field actually written (may differ from the requested field)")
+    field: str = Field(
+        description="Binary field actually written (may differ from the requested field)"
+    )
     size_bytes: int = Field(description="Size of the uploaded bytes (before base64 encoding)")
     url: str = Field(description="Direct URL to the record in Odoo web interface")
     message: str = Field(description="Human-readable success or warning message")

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -18,7 +18,6 @@ from mcp.server.transport_security import TransportSecuritySettings
 
 from .access_control import AccessController
 from .config import OdooConfig, get_config
-from .odoo_knowledge import SERVER_INSTRUCTIONS
 from .error_handling import (
     ConfigurationError,
     ErrorContext,
@@ -28,6 +27,7 @@ from .exceptions import OdooConnectionError
 from .logging_config import get_logger, logging_config, perf_logger
 from .odoo_connection import OdooConnection
 from .odoo_json2_connection import OdooJSON2Connection
+from .odoo_knowledge import SERVER_INSTRUCTIONS
 from .performance import PerformanceManager
 from .resources import register_resources
 from .skills import register_skills
@@ -45,21 +45,25 @@ _BUILD_ORIGIN = "pnl-mcp-7f3a"  # Pantalytics provenance tag
 # Dynamic Client Registration (RFC 7591) — allowed redirect_uri hosts.
 # Intentionally not env-configurable: anti-abuse guardrail against arbitrary
 # URIs being registered in Zitadel.
-_DCR_ALLOWED_HOSTS = frozenset({
-    "chatgpt.com",
-    "chat.openai.com",
-    "claude.ai",
-    "localhost",
-    "127.0.0.1",
-})
+_DCR_ALLOWED_HOSTS = frozenset(
+    {
+        "chatgpt.com",
+        "chat.openai.com",
+        "claude.ai",
+        "localhost",
+        "127.0.0.1",
+    }
+)
 # Hosts that resolve against the pre-configured static OIDC app
 # (MCP_OIDC_CLIENT_ID) with no Zitadel mutation. Everything else goes
 # through the dynamic DCR app.
-_DCR_STATIC_HOSTS = frozenset({
-    "claude.ai",
-    "localhost",
-    "127.0.0.1",
-})
+_DCR_STATIC_HOSTS = frozenset(
+    {
+        "claude.ai",
+        "localhost",
+        "127.0.0.1",
+    }
+)
 _DCR_MAX_URIS_PER_REQUEST = 5
 
 
@@ -96,9 +100,7 @@ async def _append_redirect_uris_to_dcr_app(
         except httpx.HTTPError as e:
             raise _DCRUpdateError(f"GET app network error: {e}") from e
         if r.status_code != 200:
-            raise _DCRUpdateError(
-                f"GET app failed: {r.status_code} {r.text[:200]}"
-            )
+            raise _DCRUpdateError(f"GET app failed: {r.status_code} {r.text[:200]}")
         oidc = (r.json().get("app") or {}).get("oidcConfig") or {}
         if not oidc:
             raise _DCRUpdateError("app has no oidcConfig (wrong app_id?)")
@@ -111,24 +113,28 @@ async def _append_redirect_uris_to_dcr_app(
 
         # PUT requires the full OIDC config. Preserve every field we got
         # from GET; only override redirectUris.
-        put_body = {k: v for k, v in {
-            "redirectUris": sorted(merged),
-            "responseTypes": oidc.get("responseTypes"),
-            "grantTypes": oidc.get("grantTypes"),
-            "appType": oidc.get("appType"),
-            "authMethodType": oidc.get("authMethodType"),
-            "postLogoutRedirectUris": oidc.get("postLogoutRedirectUris"),
-            "devMode": oidc.get("devMode"),
-            "accessTokenType": oidc.get("accessTokenType"),
-            "accessTokenRoleAssertion": oidc.get("accessTokenRoleAssertion"),
-            "idTokenRoleAssertion": oidc.get("idTokenRoleAssertion"),
-            "idTokenUserinfoAssertion": oidc.get("idTokenUserinfoAssertion"),
-            "clockSkew": oidc.get("clockSkew"),
-            "additionalOrigins": oidc.get("additionalOrigins"),
-            "skipNativeAppSuccessPage": oidc.get("skipNativeAppSuccessPage"),
-            "backChannelLogoutUri": oidc.get("backChannelLogoutUri"),
-            "loginVersion": oidc.get("loginVersion"),
-        }.items() if v is not None}
+        put_body = {
+            k: v
+            for k, v in {
+                "redirectUris": sorted(merged),
+                "responseTypes": oidc.get("responseTypes"),
+                "grantTypes": oidc.get("grantTypes"),
+                "appType": oidc.get("appType"),
+                "authMethodType": oidc.get("authMethodType"),
+                "postLogoutRedirectUris": oidc.get("postLogoutRedirectUris"),
+                "devMode": oidc.get("devMode"),
+                "accessTokenType": oidc.get("accessTokenType"),
+                "accessTokenRoleAssertion": oidc.get("accessTokenRoleAssertion"),
+                "idTokenRoleAssertion": oidc.get("idTokenRoleAssertion"),
+                "idTokenUserinfoAssertion": oidc.get("idTokenUserinfoAssertion"),
+                "clockSkew": oidc.get("clockSkew"),
+                "additionalOrigins": oidc.get("additionalOrigins"),
+                "skipNativeAppSuccessPage": oidc.get("skipNativeAppSuccessPage"),
+                "backChannelLogoutUri": oidc.get("backChannelLogoutUri"),
+                "loginVersion": oidc.get("loginVersion"),
+            }.items()
+            if v is not None
+        }
 
         try:
             r = await client.put(put_url, headers=headers, json=put_body)
@@ -142,9 +148,7 @@ async def _append_redirect_uris_to_dcr_app(
         # outcome either way — treat as success.
         if r.status_code == 400 and "No changes" in r.text:
             return
-        raise _DCRUpdateError(
-            f"PUT config failed: {r.status_code} {r.text[:200]}"
-        )
+        raise _DCRUpdateError(f"PUT config failed: {r.status_code} {r.text[:200]}")
 
 
 class OdooMCPServer:
@@ -175,8 +179,11 @@ class OdooMCPServer:
         self.resource_handler = None
         self.tool_handler = None
 
-        # Multi-tenant registry (HTTP mode with admin panel)
-        self.db_manager: Optional[DatabaseManager] = None
+        # Multi-tenant registry (HTTP mode with admin panel).
+        # DatabaseManager type is intentionally Any: it lives in the
+        # private admin package, which isn't a static dependency of the
+        # public repo. Lazy-imported at runtime in _setup_multi_tenant.
+        self.db_manager: Optional[Any] = None
         self.registry: Optional[ConnectionRegistry] = None
 
         # Configure OAuth if environment variables are set
@@ -235,7 +242,6 @@ class OdooMCPServer:
 
         zitadel = zitadel_issuer_url.rstrip("/") if zitadel_issuer_url else issuer_url.rstrip("/")
         # Extract server root (without /mcp path) for authorization_servers
-        from urllib.parse import urlparse
 
         parsed = urlparse(resource_server_url)
         server_root = f"{parsed.scheme}://{parsed.netloc}"
@@ -356,9 +362,7 @@ class OdooMCPServer:
                     )
                 host = (parsed.hostname or "").lower()
                 if host not in _DCR_ALLOWED_HOSTS:
-                    logger.warning(
-                        f"DCR rejected: host={host!r} not in allowlist (uri={uri})"
-                    )
+                    logger.warning(f"DCR rejected: host={host!r} not in allowlist (uri={uri})")
                     return JSONResponse(
                         {
                             "error": "invalid_redirect_uri",
@@ -380,13 +384,8 @@ class OdooMCPServer:
             }
 
             if all_static:
-                logger.info(
-                    f"DCR static-path: client={client_name!r} "
-                    f"hosts={sorted(set(hosts))}"
-                )
-                return JSONResponse(
-                    {"client_id": oidc_client_id, **common_response_fields}
-                )
+                logger.info(f"DCR static-path: client={client_name!r} hosts={sorted(set(hosts))}")
+                return JSONResponse({"client_id": oidc_client_id, **common_response_fields})
 
             # Dynamic-path — mutate DCR app in Zitadel
             dcr_client_id = os.getenv("MCP_OIDC_DCR_CLIENT_ID", "").strip()
@@ -395,23 +394,22 @@ class OdooMCPServer:
             zitadel_pat = os.getenv("ZITADEL_PAT", "").strip()
 
             missing = [
-                name for name, value in [
+                name
+                for name, value in [
                     ("MCP_OIDC_DCR_CLIENT_ID", dcr_client_id),
                     ("MCP_OIDC_DCR_APP_ID", dcr_app_id),
                     ("MCP_OIDC_DCR_PROJECT_ID", dcr_project_id),
                     ("ZITADEL_PAT", zitadel_pat),
-                ] if not value
+                ]
+                if not value
             ]
             if missing:
-                logger.error(
-                    f"DCR dynamic-path blocked: missing env: {missing}"
-                )
+                logger.error(f"DCR dynamic-path blocked: missing env: {missing}")
                 return JSONResponse(
                     {
                         "error": "server_error",
                         "error_description": (
-                            f"DCR not configured on server "
-                            f"(missing: {', '.join(missing)})"
+                            f"DCR not configured on server (missing: {', '.join(missing)})"
                         ),
                     },
                     status_code=500,
@@ -439,9 +437,7 @@ class OdooMCPServer:
                 f"DCR dynamic-path: client={client_name!r} "
                 f"hosts={sorted(set(hosts))} uris={len(raw_uris)}"
             )
-            return JSONResponse(
-                {"client_id": dcr_client_id, **common_response_fields}
-            )
+            return JSONResponse({"client_id": dcr_client_id, **common_response_fields})
 
     @staticmethod
     def _build_oauth_settings():
@@ -677,12 +673,12 @@ class OdooMCPServer:
                     # Multi-tenant mode: requires odoo-mcp-pro-admin package
                     try:
                         from .admin.db import DatabaseManager
-                    except ImportError:
+                    except ImportError as e:
                         raise ConfigurationError(
                             "DATABASE_URL is set but the admin package is not installed. "
                             "Install odoo-mcp-pro-admin for multi-tenant mode, or unset "
                             "DATABASE_URL for single-tenant mode."
-                        )
+                        ) from e
                     from .registry import ConnectionRegistry
 
                     logger.info("Starting in multi-tenant mode (DATABASE_URL configured)")
@@ -724,6 +720,7 @@ class OdooMCPServer:
                 # Multi-tenant: mount admin panel alongside MCP (requires admin package)
                 try:
                     from starlette.routing import Mount
+
                     from .admin.app import create_admin_app
 
                     issuer_url = os.getenv("OAUTH_ISSUER_URL", "").strip()

--- a/mcp_server_odoo/skills.py
+++ b/mcp_server_odoo/skills.py
@@ -94,22 +94,20 @@ def discover_skills() -> List[Dict[str, object]]:
         name = meta.get("name") or child.name
         description = meta.get("description") or f"Odoo workflow skill: {name}"
         triggers = _parse_triggers(meta.get("triggers", ""))
-        out.append({
-            "name": name,
-            "description": description,
-            "path": str(skill_md),
-            "triggers": triggers,
-        })
+        out.append(
+            {
+                "name": name,
+                "description": description,
+                "path": str(skill_md),
+                "triggers": triggers,
+            }
+        )
     return out
 
 
 def _companion_files(skill_dir: Path) -> List[Path]:
     """Every *.md under skill_dir except SKILL.md itself, recursive."""
-    return sorted(
-        p
-        for p in skill_dir.rglob("*.md")
-        if p.name != "SKILL.md" and p.is_file()
-    )
+    return sorted(p for p in skill_dir.rglob("*.md") if p.name != "SKILL.md" and p.is_file())
 
 
 def _make_reader(path: Path, fn_name: str):
@@ -121,8 +119,10 @@ def _make_reader(path: Path, fn_name: str):
     The `fn_name` is surfaced via `__name__` so resources list with a real name
     instead of all showing as `_read`.
     """
+
     async def _read() -> str:
         return path.read_text(encoding="utf-8")
+
     _read.__name__ = fn_name
     return _read
 
@@ -145,9 +145,6 @@ def register_skills(app: FastMCP) -> int:
 
     # Build lookup maps for the tool handlers
     skill_by_name: Dict[str, Path] = {str(s["name"]): Path(str(s["path"])) for s in skills}
-    skill_index: List[Dict[str, str]] = [
-        {"name": str(s["name"]), "description": str(s["description"])} for s in skills
-    ]
     # For find_skill matching: pre-compile one regex per skill matching
     # any of its triggers at a word-start boundary (so "offerte" matches
     # "offertes", but trigger "po" does NOT match inside "importeer").

--- a/mcp_server_odoo/skills.py
+++ b/mcp_server_odoo/skills.py
@@ -133,7 +133,7 @@ def register_skills(app: FastMCP) -> int:
     Resources (skill://{name}) are discoverable by MCP clients that
     surface them in their UI (browse/@-mention). Claude.ai's web client
     currently only surfaces resources to users, not to the model, so
-    we also expose `list_skills` and `get_skill` as tools so the model
+    we also expose `find_skill` and `get_skill` as tools so the model
     can pull a skill into context on its own when a workflow needs it.
 
     Safe to call at server init — no Odoo connection required.
@@ -208,11 +208,13 @@ def register_skills(app: FastMCP) -> int:
     async def find_skill(question: str) -> Dict[str, object]:
         """Return the Odoo skill most relevant to a question, with its content.
 
-        Prefer this single tool over `list_skills` + `get_skill` — it
-        picks the right skill by keyword match and returns its full
-        markdown guide in one call. Use when you're about to execute a
-        domain workflow (selling, buying, inventory, etc.) and want the
-        reference material first.
+        Prefer this tool — it picks the right skill by keyword match
+        and returns its full markdown guide in one call. Use when
+        you're about to execute a domain workflow (selling, buying,
+        inventory, etc.) and want the reference material first.
+
+        If `find_skill` returns nothing, fall back to `get_skill(name)`
+        with a guessed name.
 
         Args:
             question: The user's question or task description, any language.
@@ -248,28 +250,6 @@ def register_skills(app: FastMCP) -> int:
         return result
 
     @app.tool(
-        title="List Odoo Skills",
-        annotations=ToolAnnotations(
-            readOnlyHint=True,
-            destructiveHint=False,
-            idempotentHint=True,
-            openWorldHint=False,
-        ),
-    )
-    async def list_skills() -> List[Dict[str, str]]:
-        """Browse all Odoo workflow skills.
-
-        Fallback for when `find_skill` returned nothing or you want to
-        see the full catalogue. For "which skill should I use for X?"
-        prefer `find_skill(question=X)` — it picks and returns content
-        in one call.
-
-        Returns:
-            A list of {name, description} entries.
-        """
-        return skill_index
-
-    @app.tool(
         title="Get Odoo Skill",
         annotations=ToolAnnotations(
             readOnlyHint=True,
@@ -285,7 +265,7 @@ def register_skills(app: FastMCP) -> int:
         executing a multi-step workflow in that domain.
 
         Args:
-            name: Skill name as returned by `list_skills` (e.g. "selling").
+            name: Skill name as returned by `find_skill` (e.g. "selling").
 
         Returns:
             The markdown body of the SKILL.md file. Empty string if
@@ -303,6 +283,6 @@ def register_skills(app: FastMCP) -> int:
     logger.info(
         f"Registered {len(skills)} skill resources "
         f"({companion_count} companion files) "
-        f"+ 3 tools (find_skill, list_skills, get_skill)"
+        f"+ 2 tools (find_skill, get_skill)"
     )
     return len(skills)

--- a/mcp_server_odoo/tools.py
+++ b/mcp_server_odoo/tools.py
@@ -7,6 +7,7 @@ actions like creating, updating, or deleting records.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import contextvars
 import json
@@ -54,6 +55,8 @@ logger = get_logger(__name__)
 
 MAX_BULK_SIZE = 1000  # Maximum records per bulk operation
 MAX_BINARY_SIZE_BYTES = 25 * 1024 * 1024  # set_binary_field upload cap
+MAX_CONCURRENT_BINARY_UPLOADS = 3  # parallel set_binary_field calls; higher OOMs the server
+_BINARY_UPLOAD_SEMAPHORE = asyncio.Semaphore(MAX_CONCURRENT_BINARY_UPLOADS)
 _AVATAR_FIELD_RE = re.compile(r"^avatar_(128|256|512|1024|1920)$")
 
 # ContextVar to pass the current user's sub from _get_user_context to the wrapper
@@ -1661,141 +1664,142 @@ class OdooToolHandler:
         the base64 string via connection.write.
         """
         try:
-            connection, access_controller, sub = await self._get_user_context()
-            with perf_logger.track_operation("tool_set_binary_field", model=model):
-                access_controller.validate_model_access(model, "write")
-                if not connection.is_authenticated:
-                    raise ValidationError("Not authenticated with Odoo")
-                if not field_name:
-                    raise ValidationError("field_name is required")
-                if not source:
-                    raise ValidationError("source is required (http(s) URL)")
+            async with _BINARY_UPLOAD_SEMAPHORE:
+                connection, access_controller, sub = await self._get_user_context()
+                with perf_logger.track_operation("tool_set_binary_field", model=model):
+                    access_controller.validate_model_access(model, "write")
+                    if not connection.is_authenticated:
+                        raise ValidationError("Not authenticated with Odoo")
+                    if not field_name:
+                        raise ValidationError("field_name is required")
+                    if not source:
+                        raise ValidationError("source is required (http(s) URL)")
 
-                # --- Fetch bytes from URL ---
-                # Reject data: URIs: they would force the LLM to carry the full
-                # base64 payload in the tool call, which defeats the purpose of
-                # this tool. The user should upload the file somewhere reachable
-                # (Drive/Dropbox/S3/etc.) and pass the URL.
-                if source.startswith("data:"):
-                    raise ValidationError(
-                        "data: URIs are not accepted — bytes must not pass through the "
-                        "LLM. Upload the file to a reachable URL (Google Drive share, "
-                        "Dropbox direct link, S3 pre-signed URL, etc.) and pass the URL."
+                    # --- Fetch bytes from URL ---
+                    # Reject data: URIs: they would force the LLM to carry the full
+                    # base64 payload in the tool call, which defeats the purpose of
+                    # this tool. The user should upload the file somewhere reachable
+                    # (Drive/Dropbox/S3/etc.) and pass the URL.
+                    if source.startswith("data:"):
+                        raise ValidationError(
+                            "data: URIs are not accepted — bytes must not pass through the "
+                            "LLM. Upload the file to a reachable URL (Google Drive share, "
+                            "Dropbox direct link, S3 pre-signed URL, etc.) and pass the URL."
+                        )
+                    parsed = urlparse(source)
+                    if parsed.scheme not in ("http", "https"):
+                        raise ValidationError(
+                            f"source must be an http(s) URL, got scheme '{parsed.scheme}'"
+                        )
+                    if not parsed.netloc:
+                        raise ValidationError("source URL is missing a host")
+                    try:
+                        async with httpx.AsyncClient(
+                            timeout=30.0,
+                            follow_redirects=True,
+                            max_redirects=5,
+                        ) as client:
+                            chunks: List[bytes] = []
+                            total = 0
+                            async with client.stream("GET", source) as resp:
+                                resp.raise_for_status()
+                                async for chunk in resp.aiter_bytes(chunk_size=65536):
+                                    total += len(chunk)
+                                    if total > MAX_BINARY_SIZE_BYTES:
+                                        raise ValidationError(
+                                            f"Source exceeds max size of "
+                                            f"{MAX_BINARY_SIZE_BYTES // (1024 * 1024)} MB"
+                                        )
+                                    chunks.append(chunk)
+                            raw_bytes = b"".join(chunks)
+                    except ValidationError:
+                        raise
+                    except httpx.HTTPError as e:
+                        raise ValidationError(f"Failed to fetch source URL: {e}") from e
+
+                    if not raw_bytes:
+                        raise ValidationError("Source produced zero bytes")
+
+                    # --- Validate record exists ---
+                    existing = connection.read(model, [record_id], ["id"])
+                    if not existing:
+                        raise NotFoundError(f"Record not found: {model} with ID {record_id}")
+
+                    # --- Validate field type + auto-redirect avatar_* ---
+                    fields_info = connection.fields_get(model)
+                    if not isinstance(fields_info, dict):
+                        raise ValidationError(f"Could not introspect fields of {model}")
+
+                    target_field = field_name
+                    warning: Optional[str] = None
+
+                    # Avatar fields on avatar.mixin are compute-only without inverse;
+                    # writing to them is a silent no-op. Redirect to image_1920 if present.
+                    if _AVATAR_FIELD_RE.match(field_name) and "image_1920" in fields_info:
+                        target_field = "image_1920"
+                        warning = (
+                            f"'{field_name}' is a computed field without an inverse; "
+                            f"wrote to 'image_1920' instead (avatar/image variants recompute automatically)"
+                        )
+
+                    # product.product.image_1920 has a fall-through inverse: if the
+                    # template image is empty OR the template has only one active
+                    # variant, the write lands on product.template instead of the
+                    # variant. Use 'image_variant_1920' to force variant-specific
+                    # storage. Don't auto-redirect (user may legitimately want the
+                    # template-wide write); just warn.
+                    if (
+                        model == "product.product"
+                        and field_name == "image_1920"
+                        and "image_variant_1920" in fields_info
+                    ):
+                        warning = (
+                            "writes to product.product.image_1920 may fall through to "
+                            "product.template (if template image is empty or only one "
+                            "active variant exists). Use field_name='image_variant_1920' "
+                            "for guaranteed variant-specific storage."
+                        )
+
+                    if target_field not in fields_info:
+                        raise ValidationError(
+                            f"Field '{target_field}' does not exist on model '{model}'"
+                        )
+
+                    ftype = fields_info[target_field].get("type")
+                    if ftype not in ("binary", "image"):
+                        raise ValidationError(
+                            f"Field '{target_field}' is type '{ftype}', not binary/image"
+                        )
+                    if fields_info[target_field].get("readonly"):
+                        raise ValidationError(
+                            f"Field '{target_field}' on '{model}' is readonly"
+                        )
+
+                    # --- Write (Odoo ORM creates/updates backing ir.attachment) ---
+                    b64 = base64.b64encode(raw_bytes).decode("ascii")
+                    success = connection.write(model, [record_id], {target_field: b64})
+
+                    base_url = (
+                        getattr(connection, "_base_url", None)
+                        or (self.config.url if self.config else "")
+                    ).rstrip("/")
+                    record_url = f"{base_url}/web#id={record_id}&model={model}&view_type=form"
+
+                    message = (
+                        f"Wrote {len(raw_bytes)} bytes to {model}({record_id}).{target_field}"
                     )
-                parsed = urlparse(source)
-                if parsed.scheme not in ("http", "https"):
-                    raise ValidationError(
-                        f"source must be an http(s) URL, got scheme '{parsed.scheme}'"
-                    )
-                if not parsed.netloc:
-                    raise ValidationError("source URL is missing a host")
-                try:
-                    async with httpx.AsyncClient(
-                        timeout=30.0,
-                        follow_redirects=True,
-                        max_redirects=5,
-                    ) as client:
-                        chunks: List[bytes] = []
-                        total = 0
-                        async with client.stream("GET", source) as resp:
-                            resp.raise_for_status()
-                            async for chunk in resp.aiter_bytes(chunk_size=65536):
-                                total += len(chunk)
-                                if total > MAX_BINARY_SIZE_BYTES:
-                                    raise ValidationError(
-                                        f"Source exceeds max size of "
-                                        f"{MAX_BINARY_SIZE_BYTES // (1024 * 1024)} MB"
-                                    )
-                                chunks.append(chunk)
-                        raw_bytes = b"".join(chunks)
-                except ValidationError:
-                    raise
-                except httpx.HTTPError as e:
-                    raise ValidationError(f"Failed to fetch source URL: {e}") from e
+                    if warning:
+                        message = f"{message}. Note: {warning}"
 
-                if not raw_bytes:
-                    raise ValidationError("Source produced zero bytes")
-
-                # --- Validate record exists ---
-                existing = connection.read(model, [record_id], ["id"])
-                if not existing:
-                    raise NotFoundError(f"Record not found: {model} with ID {record_id}")
-
-                # --- Validate field type + auto-redirect avatar_* ---
-                fields_info = connection.fields_get(model)
-                if not isinstance(fields_info, dict):
-                    raise ValidationError(f"Could not introspect fields of {model}")
-
-                target_field = field_name
-                warning: Optional[str] = None
-
-                # Avatar fields on avatar.mixin are compute-only without inverse;
-                # writing to them is a silent no-op. Redirect to image_1920 if present.
-                if _AVATAR_FIELD_RE.match(field_name) and "image_1920" in fields_info:
-                    target_field = "image_1920"
-                    warning = (
-                        f"'{field_name}' is a computed field without an inverse; "
-                        f"wrote to 'image_1920' instead (avatar/image variants recompute automatically)"
-                    )
-
-                # product.product.image_1920 has a fall-through inverse: if the
-                # template image is empty OR the template has only one active
-                # variant, the write lands on product.template instead of the
-                # variant. Use 'image_variant_1920' to force variant-specific
-                # storage. Don't auto-redirect (user may legitimately want the
-                # template-wide write); just warn.
-                if (
-                    model == "product.product"
-                    and field_name == "image_1920"
-                    and "image_variant_1920" in fields_info
-                ):
-                    warning = (
-                        "writes to product.product.image_1920 may fall through to "
-                        "product.template (if template image is empty or only one "
-                        "active variant exists). Use field_name='image_variant_1920' "
-                        "for guaranteed variant-specific storage."
-                    )
-
-                if target_field not in fields_info:
-                    raise ValidationError(
-                        f"Field '{target_field}' does not exist on model '{model}'"
-                    )
-
-                ftype = fields_info[target_field].get("type")
-                if ftype not in ("binary", "image"):
-                    raise ValidationError(
-                        f"Field '{target_field}' is type '{ftype}', not binary/image"
-                    )
-                if fields_info[target_field].get("readonly"):
-                    raise ValidationError(
-                        f"Field '{target_field}' on '{model}' is readonly"
-                    )
-
-                # --- Write (Odoo ORM creates/updates backing ir.attachment) ---
-                b64 = base64.b64encode(raw_bytes).decode("ascii")
-                success = connection.write(model, [record_id], {target_field: b64})
-
-                base_url = (
-                    getattr(connection, "_base_url", None)
-                    or (self.config.url if self.config else "")
-                ).rstrip("/")
-                record_url = f"{base_url}/web#id={record_id}&model={model}&view_type=form"
-
-                message = (
-                    f"Wrote {len(raw_bytes)} bytes to {model}({record_id}).{target_field}"
-                )
-                if warning:
-                    message = f"{message}. Note: {warning}"
-
-                return {
-                    "success": bool(success),
-                    "model": model,
-                    "record_id": record_id,
-                    "field": target_field,
-                    "size_bytes": len(raw_bytes),
-                    "url": record_url,
-                    "message": message,
-                }
+                    return {
+                        "success": bool(success),
+                        "model": model,
+                        "record_id": record_id,
+                        "field": target_field,
+                        "size_bytes": len(raw_bytes),
+                        "url": record_url,
+                        "message": message,
+                    }
 
         except ValidationError:
             raise

--- a/mcp_server_odoo/tools.py
+++ b/mcp_server_odoo/tools.py
@@ -934,9 +934,7 @@ class OdooToolHandler:
             Returns:
                 Written field name, size in bytes, and record URL.
             """
-            result = await self._handle_set_binary_field_tool(
-                model, record_id, field_name, source
-            )
+            result = await self._handle_set_binary_field_tool(model, record_id, field_name, source)
             self._track_usage(_current_sub.get(), "set_binary_field")
             return BinaryFieldResult(**result)
 
@@ -1589,7 +1587,13 @@ class OdooToolHandler:
                 # Validate context keys (prevent dangerous keys like 'su')
                 safe_context = None
                 if context:
-                    allowed_keys = {"tracking_disable", "defer_fields_computation", "lang", "tz", "no_reset_password"}
+                    allowed_keys = {
+                        "tracking_disable",
+                        "defer_fields_computation",
+                        "lang",
+                        "tz",
+                        "no_reset_password",
+                    }
                     unsafe_keys = set(context.keys()) - allowed_keys
                     if unsafe_keys:
                         raise ValidationError(f"Context contains disallowed keys: {unsafe_keys}")
@@ -1609,7 +1613,11 @@ class OdooToolHandler:
 
                 # Separate errors from warnings
                 errors = [
-                    {"row": msg.get("rows", {}).get("from", -1), "message": msg.get("message", ""), "type": msg.get("type", "error")}
+                    {
+                        "row": msg.get("rows", {}).get("from", -1),
+                        "message": msg.get("message", ""),
+                        "type": msg.get("type", "error"),
+                    }
                     for msg in messages
                     if msg.get("type") == "error"
                 ]
@@ -1771,9 +1779,7 @@ class OdooToolHandler:
                             f"Field '{target_field}' is type '{ftype}', not binary/image"
                         )
                     if fields_info[target_field].get("readonly"):
-                        raise ValidationError(
-                            f"Field '{target_field}' on '{model}' is readonly"
-                        )
+                        raise ValidationError(f"Field '{target_field}' on '{model}' is readonly")
 
                     # --- Write (Odoo ORM creates/updates backing ir.attachment) ---
                     b64 = base64.b64encode(raw_bytes).decode("ascii")
@@ -1785,9 +1791,7 @@ class OdooToolHandler:
                     ).rstrip("/")
                     record_url = f"{base_url}/web#id={record_id}&model={model}&view_type=form"
 
-                    message = (
-                        f"Wrote {len(raw_bytes)} bytes to {model}({record_id}).{target_field}"
-                    )
+                    message = f"Wrote {len(raw_bytes)} bytes to {model}({record_id}).{target_field}"
                     if warning:
                         message = f"{message}. Note: {warning}"
 

--- a/tests/test_oauth_dcr.py
+++ b/tests/test_oauth_dcr.py
@@ -14,8 +14,8 @@ import pytest
 from mcp_server_odoo.server import (
     _DCR_ALLOWED_HOSTS,
     _DCR_STATIC_HOSTS,
-    _DCRUpdateError,
     _append_redirect_uris_to_dcr_app,
+    _DCRUpdateError,
 )
 
 
@@ -27,30 +27,29 @@ def _mock_client(responses):
     client = AsyncMock()
     client.__aenter__ = AsyncMock(return_value=client)
     client.__aexit__ = AsyncMock(return_value=False)
-    client.get = AsyncMock(side_effect=[
-        r for m, r in responses if m == "get"
-    ])
-    client.put = AsyncMock(side_effect=[
-        r for m, r in responses if m == "put"
-    ])
+    client.get = AsyncMock(side_effect=[r for m, r in responses if m == "get"])
+    client.put = AsyncMock(side_effect=[r for m, r in responses if m == "put"])
     return client
 
 
 def _get_response(existing_uris, extra=None):
     """Build a mock GET response for a Zitadel app with the given URIs."""
-    return httpx.Response(200, json={
-        "app": {
-            "oidcConfig": {
-                "redirectUris": list(existing_uris),
-                "responseTypes": ["OIDC_RESPONSE_TYPE_CODE"],
-                "grantTypes": ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"],
-                "appType": "OIDC_APP_TYPE_WEB",
-                "authMethodType": "OIDC_AUTH_METHOD_TYPE_NONE",
-                "devMode": False,
-                **(extra or {}),
+    return httpx.Response(
+        200,
+        json={
+            "app": {
+                "oidcConfig": {
+                    "redirectUris": list(existing_uris),
+                    "responseTypes": ["OIDC_RESPONSE_TYPE_CODE"],
+                    "grantTypes": ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"],
+                    "appType": "OIDC_APP_TYPE_WEB",
+                    "authMethodType": "OIDC_AUTH_METHOD_TYPE_NONE",
+                    "devMode": False,
+                    **(extra or {}),
+                },
             },
         },
-    })
+    )
 
 
 class TestDCRAllowlist:
@@ -84,10 +83,12 @@ class TestAppendRedirectUrisToDcrApp:
     async def test_appends_new_uri_and_puts(self):
         """Happy path: new URI added, PUT called with merged list."""
         new_uri = "https://chatgpt.com/connector/oauth/abc"
-        mock_client = _mock_client([
-            ("get", _get_response(["https://claude.ai/oauth/callback"])),
-            ("put", httpx.Response(200, json={"details": {}})),
-        ])
+        mock_client = _mock_client(
+            [
+                ("get", _get_response(["https://claude.ai/oauth/callback"])),
+                ("put", httpx.Response(200, json={"details": {}})),
+            ]
+        )
 
         with patch("httpx.AsyncClient", return_value=mock_client):
             await _append_redirect_uris_to_dcr_app(
@@ -111,9 +112,11 @@ class TestAppendRedirectUrisToDcrApp:
     async def test_skips_put_when_uri_already_registered(self):
         """Idempotency: repeat register of an existing URI skips PUT."""
         existing = "https://chatgpt.com/connector/oauth/abc"
-        mock_client = _mock_client([
-            ("get", _get_response([existing])),
-        ])
+        mock_client = _mock_client(
+            [
+                ("get", _get_response([existing])),
+            ]
+        )
 
         with patch("httpx.AsyncClient", return_value=mock_client):
             await _append_redirect_uris_to_dcr_app(
@@ -131,10 +134,12 @@ class TestAppendRedirectUrisToDcrApp:
         """Mix of new + existing URIs: PUT contains merged set without dupes."""
         existing = "https://chatgpt.com/connector/oauth/abc"
         new = "https://chatgpt.com/connector/oauth/xyz"
-        mock_client = _mock_client([
-            ("get", _get_response([existing])),
-            ("put", httpx.Response(200, json={"details": {}})),
-        ])
+        mock_client = _mock_client(
+            [
+                ("get", _get_response([existing])),
+                ("put", httpx.Response(200, json={"details": {}})),
+            ]
+        )
 
         with patch("httpx.AsyncClient", return_value=mock_client):
             await _append_redirect_uris_to_dcr_app(
@@ -151,9 +156,11 @@ class TestAppendRedirectUrisToDcrApp:
     @pytest.mark.asyncio
     async def test_get_non_200_raises(self):
         """GET failure surfaces as _DCRUpdateError, not silent skip."""
-        mock_client = _mock_client([
-            ("get", httpx.Response(404, text="not found")),
-        ])
+        mock_client = _mock_client(
+            [
+                ("get", httpx.Response(404, text="not found")),
+            ]
+        )
 
         with patch("httpx.AsyncClient", return_value=mock_client):
             with pytest.raises(_DCRUpdateError, match="GET app failed: 404"):
@@ -169,13 +176,18 @@ class TestAppendRedirectUrisToDcrApp:
     async def test_put_400_no_changes_is_treated_as_success(self):
         """Race: concurrent /register already added our URI. Zitadel
         returns 400 'No changes'. Idempotent, not an error."""
-        mock_client = _mock_client([
-            ("get", _get_response([])),
-            ("put", httpx.Response(
-                400,
-                json={"code": 9, "message": "No changes (COMMAND-1m88i)"},
-            )),
-        ])
+        mock_client = _mock_client(
+            [
+                ("get", _get_response([])),
+                (
+                    "put",
+                    httpx.Response(
+                        400,
+                        json={"code": 9, "message": "No changes (COMMAND-1m88i)"},
+                    ),
+                ),
+            ]
+        )
 
         with patch("httpx.AsyncClient", return_value=mock_client):
             # Must not raise
@@ -189,10 +201,12 @@ class TestAppendRedirectUrisToDcrApp:
 
     @pytest.mark.asyncio
     async def test_put_non_200_raises(self):
-        mock_client = _mock_client([
-            ("get", _get_response([])),
-            ("put", httpx.Response(403, text="forbidden")),
-        ])
+        mock_client = _mock_client(
+            [
+                ("get", _get_response([])),
+                ("put", httpx.Response(403, text="forbidden")),
+            ]
+        )
 
         with patch("httpx.AsyncClient", return_value=mock_client):
             with pytest.raises(_DCRUpdateError, match="PUT config failed: 403"):
@@ -207,9 +221,11 @@ class TestAppendRedirectUrisToDcrApp:
     @pytest.mark.asyncio
     async def test_missing_oidc_config_raises(self):
         """Wrong app_id (e.g. API app instead of OIDC app) is caught."""
-        mock_client = _mock_client([
-            ("get", httpx.Response(200, json={"app": {"apiConfig": {}}})),
-        ])
+        mock_client = _mock_client(
+            [
+                ("get", httpx.Response(200, json={"app": {"apiConfig": {}}})),
+            ]
+        )
 
         with patch("httpx.AsyncClient", return_value=mock_client):
             with pytest.raises(_DCRUpdateError, match="no oidcConfig"):
@@ -241,10 +257,12 @@ class TestAppendRedirectUrisToDcrApp:
     @pytest.mark.asyncio
     async def test_trailing_slash_in_base_url_handled(self):
         """zitadel_base_url may come in with or without trailing slash."""
-        mock_client = _mock_client([
-            ("get", _get_response([])),
-            ("put", httpx.Response(200, json={})),
-        ])
+        mock_client = _mock_client(
+            [
+                ("get", _get_response([])),
+                ("put", httpx.Response(200, json={})),
+            ]
+        )
 
         with patch("httpx.AsyncClient", return_value=mock_client):
             await _append_redirect_uris_to_dcr_app(

--- a/tests/test_oauth_dcr_integration.py
+++ b/tests/test_oauth_dcr_integration.py
@@ -26,10 +26,9 @@ import httpx
 import pytest
 
 from mcp_server_odoo.server import (
-    _DCRUpdateError,
     _append_redirect_uris_to_dcr_app,
+    _DCRUpdateError,
 )
-
 
 pytestmark = pytest.mark.integration
 
@@ -45,6 +44,7 @@ REQUIRED_ENV = [
 def _zitadel_reachable(url: str) -> bool:
     try:
         from urllib.parse import urlparse
+
         parsed = urlparse(url)
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(1)
@@ -67,8 +67,7 @@ if _env_missing():
 
 if not _zitadel_reachable(os.environ["ZITADEL_TEST_URL"]):
     pytest.skip(
-        f"skipping DCR integration: Zitadel not reachable at "
-        f"{os.environ['ZITADEL_TEST_URL']}",
+        f"skipping DCR integration: Zitadel not reachable at {os.environ['ZITADEL_TEST_URL']}",
         allow_module_level=True,
     )
 
@@ -110,15 +109,19 @@ def _reset_redirect_uris(cfg) -> None:
     )
     r.raise_for_status()
     oidc = (r.json().get("app") or {}).get("oidcConfig") or {}
-    put_body = {k: v for k, v in {
-        "redirectUris": [BOOTSTRAP_URI],
-        "responseTypes": oidc.get("responseTypes"),
-        "grantTypes": oidc.get("grantTypes"),
-        "appType": oidc.get("appType"),
-        "authMethodType": oidc.get("authMethodType"),
-        "postLogoutRedirectUris": oidc.get("postLogoutRedirectUris"),
-        "devMode": oidc.get("devMode"),
-    }.items() if v is not None}
+    put_body = {
+        k: v
+        for k, v in {
+            "redirectUris": [BOOTSTRAP_URI],
+            "responseTypes": oidc.get("responseTypes"),
+            "grantTypes": oidc.get("grantTypes"),
+            "appType": oidc.get("appType"),
+            "authMethodType": oidc.get("authMethodType"),
+            "postLogoutRedirectUris": oidc.get("postLogoutRedirectUris"),
+            "devMode": oidc.get("devMode"),
+        }.items()
+        if v is not None
+    }
     r = httpx.put(
         f"{cfg['url']}/management/v1/projects/{cfg['project_id']}/apps/{cfg['app_id']}/oidc_config",
         headers={"Authorization": f"Bearer {cfg['pat']}"},
@@ -141,7 +144,6 @@ def clean_state(cfg):
 
 
 class TestDCRAgainstRealZitadel:
-
     @pytest.mark.asyncio
     async def test_appends_chatgpt_uri(self, cfg):
         uri = "https://chatgpt.com/connector/oauth/int-test-1"
@@ -178,13 +180,17 @@ class TestDCRAgainstRealZitadel:
         uri_b = "https://chatgpt.com/connector/oauth/int-test-b"
 
         await _append_redirect_uris_to_dcr_app(
-            zitadel_base_url=cfg["url"], pat=cfg["pat"],
-            project_id=cfg["project_id"], app_id=cfg["app_id"],
+            zitadel_base_url=cfg["url"],
+            pat=cfg["pat"],
+            project_id=cfg["project_id"],
+            app_id=cfg["app_id"],
             new_uris=[uri_a],
         )
         await _append_redirect_uris_to_dcr_app(
-            zitadel_base_url=cfg["url"], pat=cfg["pat"],
-            project_id=cfg["project_id"], app_id=cfg["app_id"],
+            zitadel_base_url=cfg["url"],
+            pat=cfg["pat"],
+            project_id=cfg["project_id"],
+            app_id=cfg["app_id"],
             new_uris=[uri_b],
         )
         uris = _get_redirect_uris(cfg)
@@ -196,8 +202,10 @@ class TestDCRAgainstRealZitadel:
         a = "https://chatgpt.com/connector/oauth/int-multi-a"
         b = "https://chat.openai.com/connector/oauth/int-multi-b"
         await _append_redirect_uris_to_dcr_app(
-            zitadel_base_url=cfg["url"], pat=cfg["pat"],
-            project_id=cfg["project_id"], app_id=cfg["app_id"],
+            zitadel_base_url=cfg["url"],
+            pat=cfg["pat"],
+            project_id=cfg["project_id"],
+            app_id=cfg["app_id"],
             new_uris=[a, b],
         )
         uris = _get_redirect_uris(cfg)
@@ -207,8 +215,10 @@ class TestDCRAgainstRealZitadel:
     async def test_wrong_app_id_raises(self, cfg):
         with pytest.raises(_DCRUpdateError, match="GET app failed"):
             await _append_redirect_uris_to_dcr_app(
-                zitadel_base_url=cfg["url"], pat=cfg["pat"],
-                project_id=cfg["project_id"], app_id="000000000000000",
+                zitadel_base_url=cfg["url"],
+                pat=cfg["pat"],
+                project_id=cfg["project_id"],
+                app_id="000000000000000",
                 new_uris=["https://chatgpt.com/x"],
             )
 
@@ -216,7 +226,9 @@ class TestDCRAgainstRealZitadel:
     async def test_invalid_pat_raises(self, cfg):
         with pytest.raises(_DCRUpdateError, match="GET app failed"):
             await _append_redirect_uris_to_dcr_app(
-                zitadel_base_url=cfg["url"], pat="invalid-pat-xxx",
-                project_id=cfg["project_id"], app_id=cfg["app_id"],
+                zitadel_base_url=cfg["url"],
+                pat="invalid-pat-xxx",
+                project_id=cfg["project_id"],
+                app_id=cfg["app_id"],
                 new_uris=["https://chatgpt.com/x"],
             )


### PR DESCRIPTION
Two unrelated improvements that were sitting uncommitted in the working tree.

## Summary

- **`skills.py`** — drops the `list_skills` tool. `find_skill(question)` is the canonical entrypoint; if it returns nothing, the model can fall back to `get_skill(name)`. Removing the catalogue tool sharpens tool-selection signal.
- **`tools.py`** — wraps `set_binary_field` in a module-level `asyncio.Semaphore(3)`. Each upload buffers up to 25 MB plus base64 expansion; without a cap, a handful of concurrent calls OOM the worker.

Two commits, one per concern, easy to revert independently if needed.

## Test plan

- [x] `pytest` runs against the branch — same 6 pre-existing failures as main (database_discovery, server_foundation, usage), no new failures
- [ ] After deploy: trigger 5 simultaneous `set_binary_field` calls; confirm 3 run in parallel, 2 queue
- [ ] After deploy: confirm Claude/ChatGPT/Le Chat tool lists no longer show list_skills (post-reconnect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)