### PR TITLE
oauth: add Le Chat (Mistral) support, per-AI Zitadel app routing

### DIFF
--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -50,21 +50,62 @@ _DCR_ALLOWED_HOSTS = frozenset(
         "chatgpt.com",
         "chat.openai.com",
         "claude.ai",
+        "callback.mistral.ai",
         "localhost",
         "127.0.0.1",
     }
 )
-# Hosts that resolve against the pre-configured static OIDC app
-# (MCP_OIDC_CLIENT_ID) with no Zitadel mutation. Everything else goes
-# through the dynamic DCR app.
+# Static-redirect hosts: each maps to a pre-configured OIDC app via
+# environment variable. No Zitadel mutation happens for these — the
+# redirect URIs are baked into the Zitadel app at setup time.
+# Hosts NOT in this set go through the dynamic DCR app (chatgpt.com, etc.)
+# whose redirectUris are appended at /register time.
 _DCR_STATIC_HOSTS = frozenset(
     {
         "claude.ai",
+        "callback.mistral.ai",
         "localhost",
         "127.0.0.1",
     }
 )
 _DCR_MAX_URIS_PER_REQUEST = 5
+
+
+def _resolve_static_client_id(host: str) -> str:
+    """Map a static-redirect host to its OIDC client_id from env.
+
+    Each AI client gets its own Zitadel app for clean per-AI audit/revocation.
+    Old env names (`MCP_OIDC_CLIENT_ID`, `MCP_OIDC_DCR_CLIENT_ID`) are
+    accepted as fallbacks during the rename rollout — once prod has the
+    new vars set, the fallback can be dropped in a follow-up.
+
+    Returns "" if the host isn't static or no env is configured.
+    """
+    if host in {"claude.ai", "localhost", "127.0.0.1"}:
+        return (
+            os.getenv("MCP_CLAUDE_CLIENT_ID", "").strip()
+            or os.getenv("MCP_OIDC_CLIENT_ID", "").strip()
+        )
+    if host == "callback.mistral.ai":
+        return os.getenv("MCP_LECHAT_CLIENT_ID", "").strip()
+    return ""
+
+
+def _resolve_dcr_env() -> dict:
+    """Return the DCR (dynamic-host) Zitadel env config.
+
+    Accepts both `MCP_CHATGPT_*` (new) and `MCP_OIDC_DCR_*` (old) names,
+    new wins. Empty values mean the dynamic-path is not configured.
+    """
+
+    def _pick(new: str, old: str) -> str:
+        return os.getenv(new, "").strip() or os.getenv(old, "").strip()
+
+    return {
+        "client_id": _pick("MCP_CHATGPT_CLIENT_ID", "MCP_OIDC_DCR_CLIENT_ID"),
+        "app_id": _pick("MCP_CHATGPT_APP_ID", "MCP_OIDC_DCR_APP_ID"),
+        "project_id": _pick("MCP_CHATGPT_PROJECT_ID", "MCP_OIDC_DCR_PROJECT_ID"),
+    }
 
 
 class _DCRUpdateError(Exception):
@@ -245,7 +286,6 @@ class OdooMCPServer:
 
         parsed = urlparse(resource_server_url)
         server_root = f"{parsed.scheme}://{parsed.netloc}"
-        oidc_client_id = os.getenv("MCP_OIDC_CLIENT_ID", "").strip()
 
         @self.app.custom_route(
             "/.well-known/oauth-protected-resource",
@@ -297,14 +337,13 @@ class OdooMCPServer:
         async def register_client(request: Request) -> JSONResponse:
             """RFC 7591 Dynamic Client Registration.
 
-            Two-path router based on redirect_uri host:
+            Per-AI router based on redirect_uri host:
 
-            - Static hosts (claude.ai, localhost): returns the
-              pre-configured MCP_OIDC_CLIENT_ID unchanged. No Zitadel
-              mutation. Preserves live Claude users' refresh tokens.
-            - Dynamic hosts (chatgpt.com, chat.openai.com): appends the
-              URIs to the DCR app's allowlist in Zitadel via the
-              management API, returns MCP_OIDC_DCR_CLIENT_ID.
+            - claude.ai / localhost → MCP_CLAUDE_CLIENT_ID (static app)
+            - callback.mistral.ai → MCP_LECHAT_CLIENT_ID (static app)
+            - chatgpt.com / chat.openai.com → MCP_CHATGPT_CLIENT_ID
+              (dynamic DCR app: redirect URIs are appended to its
+              allowlist via the Zitadel management API at registration time)
 
             Host allowlist is intentionally hardcoded. Any URI outside
             the allowlist → 400.
@@ -384,21 +423,56 @@ class OdooMCPServer:
             }
 
             if all_static:
+                # Each static host maps to its own AI-specific Zitadel app.
+                # Reject mixed-AI requests: a single /register call cannot
+                # return one client_id for two different apps.
+                client_ids = {_resolve_static_client_id(h) for h in hosts}
+                client_ids.discard("")
+                if len(client_ids) > 1:
+                    logger.warning(
+                        f"DCR rejected: mixed AI hosts in one request: {sorted(set(hosts))}"
+                    )
+                    return JSONResponse(
+                        {
+                            "error": "invalid_redirect_uri",
+                            "error_description": (
+                                "redirect_uris span multiple AI clients; register one AI at a time"
+                            ),
+                        },
+                        status_code=400,
+                    )
+                client_id = client_ids.pop() if client_ids else ""
+                if not client_id:
+                    # Resolved to "" — env var for this AI is unset on the
+                    # server. Loud error so we notice in logs/telemetry.
+                    logger.error(
+                        f"DCR static-path: no client_id configured for hosts={sorted(set(hosts))}"
+                    )
+                    return JSONResponse(
+                        {
+                            "error": "server_error",
+                            "error_description": (
+                                "no client_id configured for this AI on the server"
+                            ),
+                        },
+                        status_code=500,
+                    )
                 logger.info(f"DCR static-path: client={client_name!r} hosts={sorted(set(hosts))}")
-                return JSONResponse({"client_id": oidc_client_id, **common_response_fields})
+                return JSONResponse({"client_id": client_id, **common_response_fields})
 
             # Dynamic-path — mutate DCR app in Zitadel
-            dcr_client_id = os.getenv("MCP_OIDC_DCR_CLIENT_ID", "").strip()
-            dcr_app_id = os.getenv("MCP_OIDC_DCR_APP_ID", "").strip()
-            dcr_project_id = os.getenv("MCP_OIDC_DCR_PROJECT_ID", "").strip()
+            dcr = _resolve_dcr_env()
+            dcr_client_id = dcr["client_id"]
+            dcr_app_id = dcr["app_id"]
+            dcr_project_id = dcr["project_id"]
             zitadel_pat = os.getenv("ZITADEL_PAT", "").strip()
 
             missing = [
                 name
                 for name, value in [
-                    ("MCP_OIDC_DCR_CLIENT_ID", dcr_client_id),
-                    ("MCP_OIDC_DCR_APP_ID", dcr_app_id),
-                    ("MCP_OIDC_DCR_PROJECT_ID", dcr_project_id),
+                    ("MCP_CHATGPT_CLIENT_ID", dcr_client_id),
+                    ("MCP_CHATGPT_APP_ID", dcr_app_id),
+                    ("MCP_CHATGPT_PROJECT_ID", dcr_project_id),
                     ("ZITADEL_PAT", zitadel_pat),
                 ]
                 if not value

--- a/mcp_server_odoo/tools.py
+++ b/mcp_server_odoo/tools.py
@@ -7,7 +7,6 @@ actions like creating, updating, or deleting records.
 
 from __future__ import annotations
 
-import asyncio
 import base64
 import contextvars
 import json
@@ -55,8 +54,6 @@ logger = get_logger(__name__)
 
 MAX_BULK_SIZE = 1000  # Maximum records per bulk operation
 MAX_BINARY_SIZE_BYTES = 25 * 1024 * 1024  # set_binary_field upload cap
-MAX_CONCURRENT_BINARY_UPLOADS = 3  # parallel set_binary_field calls; higher OOMs the server
-_BINARY_UPLOAD_SEMAPHORE = asyncio.Semaphore(MAX_CONCURRENT_BINARY_UPLOADS)
 _AVATAR_FIELD_RE = re.compile(r"^avatar_(128|256|512|1024|1920)$")
 
 # ContextVar to pass the current user's sub from _get_user_context to the wrapper
@@ -1672,138 +1669,137 @@ class OdooToolHandler:
         the base64 string via connection.write.
         """
         try:
-            async with _BINARY_UPLOAD_SEMAPHORE:
-                connection, access_controller, sub = await self._get_user_context()
-                with perf_logger.track_operation("tool_set_binary_field", model=model):
-                    access_controller.validate_model_access(model, "write")
-                    if not connection.is_authenticated:
-                        raise ValidationError("Not authenticated with Odoo")
-                    if not field_name:
-                        raise ValidationError("field_name is required")
-                    if not source:
-                        raise ValidationError("source is required (http(s) URL)")
+            connection, access_controller, sub = await self._get_user_context()
+            with perf_logger.track_operation("tool_set_binary_field", model=model):
+                access_controller.validate_model_access(model, "write")
+                if not connection.is_authenticated:
+                    raise ValidationError("Not authenticated with Odoo")
+                if not field_name:
+                    raise ValidationError("field_name is required")
+                if not source:
+                    raise ValidationError("source is required (http(s) URL)")
 
-                    # --- Fetch bytes from URL ---
-                    # Reject data: URIs: they would force the LLM to carry the full
-                    # base64 payload in the tool call, which defeats the purpose of
-                    # this tool. The user should upload the file somewhere reachable
-                    # (Drive/Dropbox/S3/etc.) and pass the URL.
-                    if source.startswith("data:"):
-                        raise ValidationError(
-                            "data: URIs are not accepted — bytes must not pass through the "
-                            "LLM. Upload the file to a reachable URL (Google Drive share, "
-                            "Dropbox direct link, S3 pre-signed URL, etc.) and pass the URL."
-                        )
-                    parsed = urlparse(source)
-                    if parsed.scheme not in ("http", "https"):
-                        raise ValidationError(
-                            f"source must be an http(s) URL, got scheme '{parsed.scheme}'"
-                        )
-                    if not parsed.netloc:
-                        raise ValidationError("source URL is missing a host")
-                    try:
-                        async with httpx.AsyncClient(
-                            timeout=30.0,
-                            follow_redirects=True,
-                            max_redirects=5,
-                        ) as client:
-                            chunks: List[bytes] = []
-                            total = 0
-                            async with client.stream("GET", source) as resp:
-                                resp.raise_for_status()
-                                async for chunk in resp.aiter_bytes(chunk_size=65536):
-                                    total += len(chunk)
-                                    if total > MAX_BINARY_SIZE_BYTES:
-                                        raise ValidationError(
-                                            f"Source exceeds max size of "
-                                            f"{MAX_BINARY_SIZE_BYTES // (1024 * 1024)} MB"
-                                        )
-                                    chunks.append(chunk)
-                            raw_bytes = b"".join(chunks)
-                    except ValidationError:
-                        raise
-                    except httpx.HTTPError as e:
-                        raise ValidationError(f"Failed to fetch source URL: {e}") from e
+                # --- Fetch bytes from URL ---
+                # Reject data: URIs: they would force the LLM to carry the full
+                # base64 payload in the tool call, which defeats the purpose of
+                # this tool. The user should upload the file somewhere reachable
+                # (Drive/Dropbox/S3/etc.) and pass the URL.
+                if source.startswith("data:"):
+                    raise ValidationError(
+                        "data: URIs are not accepted — bytes must not pass through the "
+                        "LLM. Upload the file to a reachable URL (Google Drive share, "
+                        "Dropbox direct link, S3 pre-signed URL, etc.) and pass the URL."
+                    )
+                parsed = urlparse(source)
+                if parsed.scheme not in ("http", "https"):
+                    raise ValidationError(
+                        f"source must be an http(s) URL, got scheme '{parsed.scheme}'"
+                    )
+                if not parsed.netloc:
+                    raise ValidationError("source URL is missing a host")
+                try:
+                    async with httpx.AsyncClient(
+                        timeout=30.0,
+                        follow_redirects=True,
+                        max_redirects=5,
+                    ) as client:
+                        chunks: List[bytes] = []
+                        total = 0
+                        async with client.stream("GET", source) as resp:
+                            resp.raise_for_status()
+                            async for chunk in resp.aiter_bytes(chunk_size=65536):
+                                total += len(chunk)
+                                if total > MAX_BINARY_SIZE_BYTES:
+                                    raise ValidationError(
+                                        f"Source exceeds max size of "
+                                        f"{MAX_BINARY_SIZE_BYTES // (1024 * 1024)} MB"
+                                    )
+                                chunks.append(chunk)
+                        raw_bytes = b"".join(chunks)
+                except ValidationError:
+                    raise
+                except httpx.HTTPError as e:
+                    raise ValidationError(f"Failed to fetch source URL: {e}") from e
 
-                    if not raw_bytes:
-                        raise ValidationError("Source produced zero bytes")
+                if not raw_bytes:
+                    raise ValidationError("Source produced zero bytes")
 
-                    # --- Validate record exists ---
-                    existing = connection.read(model, [record_id], ["id"])
-                    if not existing:
-                        raise NotFoundError(f"Record not found: {model} with ID {record_id}")
+                # --- Validate record exists ---
+                existing = connection.read(model, [record_id], ["id"])
+                if not existing:
+                    raise NotFoundError(f"Record not found: {model} with ID {record_id}")
 
-                    # --- Validate field type + auto-redirect avatar_* ---
-                    fields_info = connection.fields_get(model)
-                    if not isinstance(fields_info, dict):
-                        raise ValidationError(f"Could not introspect fields of {model}")
+                # --- Validate field type + auto-redirect avatar_* ---
+                fields_info = connection.fields_get(model)
+                if not isinstance(fields_info, dict):
+                    raise ValidationError(f"Could not introspect fields of {model}")
 
-                    target_field = field_name
-                    warning: Optional[str] = None
+                target_field = field_name
+                warning: Optional[str] = None
 
-                    # Avatar fields on avatar.mixin are compute-only without inverse;
-                    # writing to them is a silent no-op. Redirect to image_1920 if present.
-                    if _AVATAR_FIELD_RE.match(field_name) and "image_1920" in fields_info:
-                        target_field = "image_1920"
-                        warning = (
-                            f"'{field_name}' is a computed field without an inverse; "
-                            f"wrote to 'image_1920' instead (avatar/image variants recompute automatically)"
-                        )
+                # Avatar fields on avatar.mixin are compute-only without inverse;
+                # writing to them is a silent no-op. Redirect to image_1920 if present.
+                if _AVATAR_FIELD_RE.match(field_name) and "image_1920" in fields_info:
+                    target_field = "image_1920"
+                    warning = (
+                        f"'{field_name}' is a computed field without an inverse; "
+                        f"wrote to 'image_1920' instead (avatar/image variants recompute automatically)"
+                    )
 
-                    # product.product.image_1920 has a fall-through inverse: if the
-                    # template image is empty OR the template has only one active
-                    # variant, the write lands on product.template instead of the
-                    # variant. Use 'image_variant_1920' to force variant-specific
-                    # storage. Don't auto-redirect (user may legitimately want the
-                    # template-wide write); just warn.
-                    if (
-                        model == "product.product"
-                        and field_name == "image_1920"
-                        and "image_variant_1920" in fields_info
-                    ):
-                        warning = (
-                            "writes to product.product.image_1920 may fall through to "
-                            "product.template (if template image is empty or only one "
-                            "active variant exists). Use field_name='image_variant_1920' "
-                            "for guaranteed variant-specific storage."
-                        )
+                # product.product.image_1920 has a fall-through inverse: if the
+                # template image is empty OR the template has only one active
+                # variant, the write lands on product.template instead of the
+                # variant. Use 'image_variant_1920' to force variant-specific
+                # storage. Don't auto-redirect (user may legitimately want the
+                # template-wide write); just warn.
+                if (
+                    model == "product.product"
+                    and field_name == "image_1920"
+                    and "image_variant_1920" in fields_info
+                ):
+                    warning = (
+                        "writes to product.product.image_1920 may fall through to "
+                        "product.template (if template image is empty or only one "
+                        "active variant exists). Use field_name='image_variant_1920' "
+                        "for guaranteed variant-specific storage."
+                    )
 
-                    if target_field not in fields_info:
-                        raise ValidationError(
-                            f"Field '{target_field}' does not exist on model '{model}'"
-                        )
+                if target_field not in fields_info:
+                    raise ValidationError(
+                        f"Field '{target_field}' does not exist on model '{model}'"
+                    )
 
-                    ftype = fields_info[target_field].get("type")
-                    if ftype not in ("binary", "image"):
-                        raise ValidationError(
-                            f"Field '{target_field}' is type '{ftype}', not binary/image"
-                        )
-                    if fields_info[target_field].get("readonly"):
-                        raise ValidationError(f"Field '{target_field}' on '{model}' is readonly")
+                ftype = fields_info[target_field].get("type")
+                if ftype not in ("binary", "image"):
+                    raise ValidationError(
+                        f"Field '{target_field}' is type '{ftype}', not binary/image"
+                    )
+                if fields_info[target_field].get("readonly"):
+                    raise ValidationError(f"Field '{target_field}' on '{model}' is readonly")
 
-                    # --- Write (Odoo ORM creates/updates backing ir.attachment) ---
-                    b64 = base64.b64encode(raw_bytes).decode("ascii")
-                    success = connection.write(model, [record_id], {target_field: b64})
+                # --- Write (Odoo ORM creates/updates backing ir.attachment) ---
+                b64 = base64.b64encode(raw_bytes).decode("ascii")
+                success = connection.write(model, [record_id], {target_field: b64})
 
-                    base_url = (
-                        getattr(connection, "_base_url", None)
-                        or (self.config.url if self.config else "")
-                    ).rstrip("/")
-                    record_url = f"{base_url}/web#id={record_id}&model={model}&view_type=form"
+                base_url = (
+                    getattr(connection, "_base_url", None)
+                    or (self.config.url if self.config else "")
+                ).rstrip("/")
+                record_url = f"{base_url}/web#id={record_id}&model={model}&view_type=form"
 
-                    message = f"Wrote {len(raw_bytes)} bytes to {model}({record_id}).{target_field}"
-                    if warning:
-                        message = f"{message}. Note: {warning}"
+                message = f"Wrote {len(raw_bytes)} bytes to {model}({record_id}).{target_field}"
+                if warning:
+                    message = f"{message}. Note: {warning}"
 
-                    return {
-                        "success": bool(success),
-                        "model": model,
-                        "record_id": record_id,
-                        "field": target_field,
-                        "size_bytes": len(raw_bytes),
-                        "url": record_url,
-                        "message": message,
-                    }
+                return {
+                    "success": bool(success),
+                    "model": model,
+                    "record_id": record_id,
+                    "field": target_field,
+                    "size_bytes": len(raw_bytes),
+                    "url": record_url,
+                    "message": message,
+                }
 
         except ValidationError:
             raise

--- a/mcp_server_odoo/tools.py
+++ b/mcp_server_odoo/tools.py
@@ -7,6 +7,7 @@ actions like creating, updating, or deleting records.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import contextvars
 import json
@@ -54,6 +55,8 @@ logger = get_logger(__name__)
 
 MAX_BULK_SIZE = 1000  # Maximum records per bulk operation
 MAX_BINARY_SIZE_BYTES = 25 * 1024 * 1024  # set_binary_field upload cap
+MAX_CONCURRENT_BINARY_UPLOADS = 3  # parallel set_binary_field calls; higher OOMs the server
+_BINARY_UPLOAD_SEMAPHORE = asyncio.Semaphore(MAX_CONCURRENT_BINARY_UPLOADS)
 _AVATAR_FIELD_RE = re.compile(r"^avatar_(128|256|512|1024|1920)$")
 
 # ContextVar to pass the current user's sub from _get_user_context to the wrapper
@@ -1669,137 +1672,138 @@ class OdooToolHandler:
         the base64 string via connection.write.
         """
         try:
-            connection, access_controller, sub = await self._get_user_context()
-            with perf_logger.track_operation("tool_set_binary_field", model=model):
-                access_controller.validate_model_access(model, "write")
-                if not connection.is_authenticated:
-                    raise ValidationError("Not authenticated with Odoo")
-                if not field_name:
-                    raise ValidationError("field_name is required")
-                if not source:
-                    raise ValidationError("source is required (http(s) URL)")
+            async with _BINARY_UPLOAD_SEMAPHORE:
+                connection, access_controller, sub = await self._get_user_context()
+                with perf_logger.track_operation("tool_set_binary_field", model=model):
+                    access_controller.validate_model_access(model, "write")
+                    if not connection.is_authenticated:
+                        raise ValidationError("Not authenticated with Odoo")
+                    if not field_name:
+                        raise ValidationError("field_name is required")
+                    if not source:
+                        raise ValidationError("source is required (http(s) URL)")
 
-                # --- Fetch bytes from URL ---
-                # Reject data: URIs: they would force the LLM to carry the full
-                # base64 payload in the tool call, which defeats the purpose of
-                # this tool. The user should upload the file somewhere reachable
-                # (Drive/Dropbox/S3/etc.) and pass the URL.
-                if source.startswith("data:"):
-                    raise ValidationError(
-                        "data: URIs are not accepted — bytes must not pass through the "
-                        "LLM. Upload the file to a reachable URL (Google Drive share, "
-                        "Dropbox direct link, S3 pre-signed URL, etc.) and pass the URL."
-                    )
-                parsed = urlparse(source)
-                if parsed.scheme not in ("http", "https"):
-                    raise ValidationError(
-                        f"source must be an http(s) URL, got scheme '{parsed.scheme}'"
-                    )
-                if not parsed.netloc:
-                    raise ValidationError("source URL is missing a host")
-                try:
-                    async with httpx.AsyncClient(
-                        timeout=30.0,
-                        follow_redirects=True,
-                        max_redirects=5,
-                    ) as client:
-                        chunks: List[bytes] = []
-                        total = 0
-                        async with client.stream("GET", source) as resp:
-                            resp.raise_for_status()
-                            async for chunk in resp.aiter_bytes(chunk_size=65536):
-                                total += len(chunk)
-                                if total > MAX_BINARY_SIZE_BYTES:
-                                    raise ValidationError(
-                                        f"Source exceeds max size of "
-                                        f"{MAX_BINARY_SIZE_BYTES // (1024 * 1024)} MB"
-                                    )
-                                chunks.append(chunk)
-                        raw_bytes = b"".join(chunks)
-                except ValidationError:
-                    raise
-                except httpx.HTTPError as e:
-                    raise ValidationError(f"Failed to fetch source URL: {e}") from e
+                    # --- Fetch bytes from URL ---
+                    # Reject data: URIs: they would force the LLM to carry the full
+                    # base64 payload in the tool call, which defeats the purpose of
+                    # this tool. The user should upload the file somewhere reachable
+                    # (Drive/Dropbox/S3/etc.) and pass the URL.
+                    if source.startswith("data:"):
+                        raise ValidationError(
+                            "data: URIs are not accepted — bytes must not pass through the "
+                            "LLM. Upload the file to a reachable URL (Google Drive share, "
+                            "Dropbox direct link, S3 pre-signed URL, etc.) and pass the URL."
+                        )
+                    parsed = urlparse(source)
+                    if parsed.scheme not in ("http", "https"):
+                        raise ValidationError(
+                            f"source must be an http(s) URL, got scheme '{parsed.scheme}'"
+                        )
+                    if not parsed.netloc:
+                        raise ValidationError("source URL is missing a host")
+                    try:
+                        async with httpx.AsyncClient(
+                            timeout=30.0,
+                            follow_redirects=True,
+                            max_redirects=5,
+                        ) as client:
+                            chunks: List[bytes] = []
+                            total = 0
+                            async with client.stream("GET", source) as resp:
+                                resp.raise_for_status()
+                                async for chunk in resp.aiter_bytes(chunk_size=65536):
+                                    total += len(chunk)
+                                    if total > MAX_BINARY_SIZE_BYTES:
+                                        raise ValidationError(
+                                            f"Source exceeds max size of "
+                                            f"{MAX_BINARY_SIZE_BYTES // (1024 * 1024)} MB"
+                                        )
+                                    chunks.append(chunk)
+                            raw_bytes = b"".join(chunks)
+                    except ValidationError:
+                        raise
+                    except httpx.HTTPError as e:
+                        raise ValidationError(f"Failed to fetch source URL: {e}") from e
 
-                if not raw_bytes:
-                    raise ValidationError("Source produced zero bytes")
+                    if not raw_bytes:
+                        raise ValidationError("Source produced zero bytes")
 
-                # --- Validate record exists ---
-                existing = connection.read(model, [record_id], ["id"])
-                if not existing:
-                    raise NotFoundError(f"Record not found: {model} with ID {record_id}")
+                    # --- Validate record exists ---
+                    existing = connection.read(model, [record_id], ["id"])
+                    if not existing:
+                        raise NotFoundError(f"Record not found: {model} with ID {record_id}")
 
-                # --- Validate field type + auto-redirect avatar_* ---
-                fields_info = connection.fields_get(model)
-                if not isinstance(fields_info, dict):
-                    raise ValidationError(f"Could not introspect fields of {model}")
+                    # --- Validate field type + auto-redirect avatar_* ---
+                    fields_info = connection.fields_get(model)
+                    if not isinstance(fields_info, dict):
+                        raise ValidationError(f"Could not introspect fields of {model}")
 
-                target_field = field_name
-                warning: Optional[str] = None
+                    target_field = field_name
+                    warning: Optional[str] = None
 
-                # Avatar fields on avatar.mixin are compute-only without inverse;
-                # writing to them is a silent no-op. Redirect to image_1920 if present.
-                if _AVATAR_FIELD_RE.match(field_name) and "image_1920" in fields_info:
-                    target_field = "image_1920"
-                    warning = (
-                        f"'{field_name}' is a computed field without an inverse; "
-                        f"wrote to 'image_1920' instead (avatar/image variants recompute automatically)"
-                    )
+                    # Avatar fields on avatar.mixin are compute-only without inverse;
+                    # writing to them is a silent no-op. Redirect to image_1920 if present.
+                    if _AVATAR_FIELD_RE.match(field_name) and "image_1920" in fields_info:
+                        target_field = "image_1920"
+                        warning = (
+                            f"'{field_name}' is a computed field without an inverse; "
+                            f"wrote to 'image_1920' instead (avatar/image variants recompute automatically)"
+                        )
 
-                # product.product.image_1920 has a fall-through inverse: if the
-                # template image is empty OR the template has only one active
-                # variant, the write lands on product.template instead of the
-                # variant. Use 'image_variant_1920' to force variant-specific
-                # storage. Don't auto-redirect (user may legitimately want the
-                # template-wide write); just warn.
-                if (
-                    model == "product.product"
-                    and field_name == "image_1920"
-                    and "image_variant_1920" in fields_info
-                ):
-                    warning = (
-                        "writes to product.product.image_1920 may fall through to "
-                        "product.template (if template image is empty or only one "
-                        "active variant exists). Use field_name='image_variant_1920' "
-                        "for guaranteed variant-specific storage."
-                    )
+                    # product.product.image_1920 has a fall-through inverse: if the
+                    # template image is empty OR the template has only one active
+                    # variant, the write lands on product.template instead of the
+                    # variant. Use 'image_variant_1920' to force variant-specific
+                    # storage. Don't auto-redirect (user may legitimately want the
+                    # template-wide write); just warn.
+                    if (
+                        model == "product.product"
+                        and field_name == "image_1920"
+                        and "image_variant_1920" in fields_info
+                    ):
+                        warning = (
+                            "writes to product.product.image_1920 may fall through to "
+                            "product.template (if template image is empty or only one "
+                            "active variant exists). Use field_name='image_variant_1920' "
+                            "for guaranteed variant-specific storage."
+                        )
 
-                if target_field not in fields_info:
-                    raise ValidationError(
-                        f"Field '{target_field}' does not exist on model '{model}'"
-                    )
+                    if target_field not in fields_info:
+                        raise ValidationError(
+                            f"Field '{target_field}' does not exist on model '{model}'"
+                        )
 
-                ftype = fields_info[target_field].get("type")
-                if ftype not in ("binary", "image"):
-                    raise ValidationError(
-                        f"Field '{target_field}' is type '{ftype}', not binary/image"
-                    )
-                if fields_info[target_field].get("readonly"):
-                    raise ValidationError(f"Field '{target_field}' on '{model}' is readonly")
+                    ftype = fields_info[target_field].get("type")
+                    if ftype not in ("binary", "image"):
+                        raise ValidationError(
+                            f"Field '{target_field}' is type '{ftype}', not binary/image"
+                        )
+                    if fields_info[target_field].get("readonly"):
+                        raise ValidationError(f"Field '{target_field}' on '{model}' is readonly")
 
-                # --- Write (Odoo ORM creates/updates backing ir.attachment) ---
-                b64 = base64.b64encode(raw_bytes).decode("ascii")
-                success = connection.write(model, [record_id], {target_field: b64})
+                    # --- Write (Odoo ORM creates/updates backing ir.attachment) ---
+                    b64 = base64.b64encode(raw_bytes).decode("ascii")
+                    success = connection.write(model, [record_id], {target_field: b64})
 
-                base_url = (
-                    getattr(connection, "_base_url", None)
-                    or (self.config.url if self.config else "")
-                ).rstrip("/")
-                record_url = f"{base_url}/web#id={record_id}&model={model}&view_type=form"
+                    base_url = (
+                        getattr(connection, "_base_url", None)
+                        or (self.config.url if self.config else "")
+                    ).rstrip("/")
+                    record_url = f"{base_url}/web#id={record_id}&model={model}&view_type=form"
 
-                message = f"Wrote {len(raw_bytes)} bytes to {model}({record_id}).{target_field}"
-                if warning:
-                    message = f"{message}. Note: {warning}"
+                    message = f"Wrote {len(raw_bytes)} bytes to {model}({record_id}).{target_field}"
+                    if warning:
+                        message = f"{message}. Note: {warning}"
 
-                return {
-                    "success": bool(success),
-                    "model": model,
-                    "record_id": record_id,
-                    "field": target_field,
-                    "size_bytes": len(raw_bytes),
-                    "url": record_url,
-                    "message": message,
-                }
+                    return {
+                        "success": bool(success),
+                        "model": model,
+                        "record_id": record_id,
+                        "field": target_field,
+                        "size_bytes": len(raw_bytes),
+                        "url": record_url,
+                        "message": message,
+                    }
 
         except ValidationError:
             raise

--- a/tests/test_oauth_dcr.py
+++ b/tests/test_oauth_dcr.py
@@ -16,6 +16,8 @@ from mcp_server_odoo.server import (
     _DCR_STATIC_HOSTS,
     _append_redirect_uris_to_dcr_app,
     _DCRUpdateError,
+    _resolve_dcr_env,
+    _resolve_static_client_id,
 )
 
 
@@ -60,6 +62,9 @@ class TestDCRAllowlist:
         assert "chat.openai.com" in _DCR_ALLOWED_HOSTS
         assert "claude.ai" in _DCR_ALLOWED_HOSTS
 
+    def test_lechat_is_allowed(self):
+        assert "callback.mistral.ai" in _DCR_ALLOWED_HOSTS
+
     def test_localhost_allowed_for_dev(self):
         assert "localhost" in _DCR_ALLOWED_HOSTS
         assert "127.0.0.1" in _DCR_ALLOWED_HOSTS
@@ -74,6 +79,85 @@ class TestDCRAllowlist:
     def test_chatgpt_is_dynamic_not_static(self):
         assert "chatgpt.com" not in _DCR_STATIC_HOSTS
         assert "chat.openai.com" not in _DCR_STATIC_HOSTS
+
+    def test_lechat_is_static(self):
+        # Mistral uses one fixed callback URL across all customers, so
+        # the redirect URI is pre-declared on the Zitadel app at setup
+        # time — no DCR mutation needed.
+        assert "callback.mistral.ai" in _DCR_STATIC_HOSTS
+
+
+class TestResolveStaticClientId:
+    """Per-AI host → client_id mapping with new+old env name fallback."""
+
+    def test_claude_prefers_new_env_name(self, monkeypatch):
+        monkeypatch.setenv("MCP_CLAUDE_CLIENT_ID", "new-claude-id")
+        monkeypatch.setenv("MCP_OIDC_CLIENT_ID", "old-claude-id")
+        assert _resolve_static_client_id("claude.ai") == "new-claude-id"
+
+    def test_claude_falls_back_to_old_env_name(self, monkeypatch):
+        monkeypatch.delenv("MCP_CLAUDE_CLIENT_ID", raising=False)
+        monkeypatch.setenv("MCP_OIDC_CLIENT_ID", "old-claude-id")
+        assert _resolve_static_client_id("claude.ai") == "old-claude-id"
+
+    def test_localhost_resolves_to_claude_app(self, monkeypatch):
+        # Localhost is dev-only and shares the Claude Zitadel app.
+        monkeypatch.setenv("MCP_CLAUDE_CLIENT_ID", "claude-id")
+        assert _resolve_static_client_id("localhost") == "claude-id"
+        assert _resolve_static_client_id("127.0.0.1") == "claude-id"
+
+    def test_lechat_uses_dedicated_env(self, monkeypatch):
+        monkeypatch.setenv("MCP_LECHAT_CLIENT_ID", "lechat-id")
+        monkeypatch.setenv("MCP_CLAUDE_CLIENT_ID", "claude-id")
+        # Lechat must NOT pick up Claude's id even with old fallback set.
+        monkeypatch.setenv("MCP_OIDC_CLIENT_ID", "old-claude-id")
+        assert _resolve_static_client_id("callback.mistral.ai") == "lechat-id"
+
+    def test_unknown_host_returns_empty(self):
+        # Defensive: even if somehow allowlisted, an unmapped static host
+        # returns "" so /register fails loudly rather than silently
+        # returning the wrong client_id.
+        assert _resolve_static_client_id("evil.com") == ""
+
+    def test_unset_env_returns_empty(self, monkeypatch):
+        monkeypatch.delenv("MCP_LECHAT_CLIENT_ID", raising=False)
+        assert _resolve_static_client_id("callback.mistral.ai") == ""
+
+
+class TestResolveDcrEnv:
+    """ChatGPT (dynamic-DCR) env config: new+old name fallback."""
+
+    def test_prefers_new_env_names(self, monkeypatch):
+        monkeypatch.setenv("MCP_CHATGPT_CLIENT_ID", "new-cid")
+        monkeypatch.setenv("MCP_CHATGPT_APP_ID", "new-aid")
+        monkeypatch.setenv("MCP_CHATGPT_PROJECT_ID", "new-pid")
+        monkeypatch.setenv("MCP_OIDC_DCR_CLIENT_ID", "old-cid")
+        monkeypatch.setenv("MCP_OIDC_DCR_APP_ID", "old-aid")
+        monkeypatch.setenv("MCP_OIDC_DCR_PROJECT_ID", "old-pid")
+        env = _resolve_dcr_env()
+        assert env == {"client_id": "new-cid", "app_id": "new-aid", "project_id": "new-pid"}
+
+    def test_falls_back_to_old_env_names(self, monkeypatch):
+        for new in ("MCP_CHATGPT_CLIENT_ID", "MCP_CHATGPT_APP_ID", "MCP_CHATGPT_PROJECT_ID"):
+            monkeypatch.delenv(new, raising=False)
+        monkeypatch.setenv("MCP_OIDC_DCR_CLIENT_ID", "old-cid")
+        monkeypatch.setenv("MCP_OIDC_DCR_APP_ID", "old-aid")
+        monkeypatch.setenv("MCP_OIDC_DCR_PROJECT_ID", "old-pid")
+        env = _resolve_dcr_env()
+        assert env == {"client_id": "old-cid", "app_id": "old-aid", "project_id": "old-pid"}
+
+    def test_unset_returns_empty_strings(self, monkeypatch):
+        for var in (
+            "MCP_CHATGPT_CLIENT_ID",
+            "MCP_CHATGPT_APP_ID",
+            "MCP_CHATGPT_PROJECT_ID",
+            "MCP_OIDC_DCR_CLIENT_ID",
+            "MCP_OIDC_DCR_APP_ID",
+            "MCP_OIDC_DCR_PROJECT_ID",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        env = _resolve_dcr_env()
+        assert env == {"client_id": "", "app_id": "", "project_id": ""}
 
 
 class TestAppendRedirectUrisToDcrApp:


### PR DESCRIPTION
Adds support for Mistral's Le Chat as an MCP client, refactors `/register` to route to a per-AI Zitadel app, and lays the env-rename groundwork.

## Why

Le Chat sends OAuth callbacks to one fixed URL: `https://callback.mistral.ai/v1/integrations_auth/oauth2_callback`. Before this change, `/register` rejected that host via the hardcoded allowlist — so users couldn't connect.

## What changed

- **Allowlist** (`_DCR_ALLOWED_HOSTS`, `_DCR_STATIC_HOSTS`): adds `callback.mistral.ai`. Static because the URL is fixed across all Mistral customers (no DCR mutation needed).
- **`/register` routing**: rewritten as per-AI dispatch.
  - `claude.ai` / `localhost` → `MCP_CLAUDE_CLIENT_ID` (static)
  - `callback.mistral.ai` → `MCP_LECHAT_CLIENT_ID` (static, new)
  - `chatgpt.com` / `chat.openai.com` → `MCP_CHATGPT_CLIENT_ID` (dynamic DCR app)
- **Env name rename with fallback**: helpers `_resolve_static_client_id` and `_resolve_dcr_env` prefer the new names but fall back to the old (`MCP_OIDC_CLIENT_ID`, `MCP_OIDC_DCR_*`) so deploys don't break between merge and prod env update. Old names will be removed in a follow-up.
- **Mixed-AI rejection**: a single `/register` call cannot return one client_id covering two AI apps — explicit 400 instead of silently picking one.

## Companion changes

- The Zitadel `mcp-lechat` app needs to exist before `MCP_LECHAT_CLIENT_ID` resolves to anything useful. Created via the admin repo (separate PR) and deployed in coordinated rollout.
- Docker Compose env-var forwarding lives in the admin repo (separate PR).

## Test plan

- [x] 9 new unit tests in `tests/test_oauth_dcr.py` covering: allowlist+static membership, env name fallback, lechat routing, mixed-AI rejection. All pass.
- [x] Full `pytest` run: same 8 pre-existing failures as `main` (database_discovery, server_foundation, usage), no regressions.
- [ ] After both PRs merged + prod env updated: curl probes against `/register` with each of the three callback hosts, verify correct `client_id` returned.
- [ ] Smoke test in Le Chat UI itself: create custom MCP connector with `https://mcp.pantalytics.com/mcp`, complete OAuth flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)