### PR TITLE
oauth: return client_secret for Le Chat (confidential client)

### DIFF
--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -91,6 +91,22 @@ def _resolve_static_client_id(host: str) -> str:
     return ""
 
 
+def _resolve_static_client_secret(host: str) -> str:
+    """Map a static-redirect host to its OIDC client_secret, if any.
+
+    Most AI clients (Claude, ChatGPT) are public clients and use PKCE only.
+    Le Chat is a confidential client per Mistral's flow: it sends
+    `token_endpoint_auth_method: "client_secret_basic"` during DCR and
+    expects a `client_secret` in the /register response, which it then
+    uses to authenticate at the Zitadel /token endpoint (alongside PKCE).
+
+    Returns "" for hosts that should be public clients.
+    """
+    if host == "callback.mistral.ai":
+        return os.getenv("MCP_LECHAT_CLIENT_SECRET", "").strip()
+    return ""
+
+
 def _resolve_dcr_env() -> dict:
     """Return the DCR (dynamic-host) Zitadel env config.
 
@@ -328,7 +344,11 @@ class OdooMCPServer:
                         "authorization_code",
                         "refresh_token",
                     ],
-                    "token_endpoint_auth_methods_supported": ["none"],
+                    "token_endpoint_auth_methods_supported": [
+                        "none",
+                        "client_secret_basic",
+                        "client_secret_post",
+                    ],
                     "code_challenge_methods_supported": ["S256"],
                 }
             )
@@ -419,7 +439,6 @@ class OdooMCPServer:
                 "redirect_uris": raw_uris,
                 "grant_types": ["authorization_code", "refresh_token"],
                 "response_types": ["code"],
-                "token_endpoint_auth_method": "none",
             }
 
             if all_static:
@@ -457,8 +476,31 @@ class OdooMCPServer:
                         },
                         status_code=500,
                     )
-                logger.info(f"DCR static-path: client={client_name!r} hosts={sorted(set(hosts))}")
-                return JSONResponse({"client_id": client_id, **common_response_fields})
+                # Confidential clients (e.g. Le Chat) need the client_secret
+                # echoed back in DCR so they can authenticate at /token via
+                # client_secret_basic. Public clients (Claude, localhost)
+                # use PKCE only. all_static guarantees all hosts map to the
+                # same AI app, so picking hosts[0] is safe.
+                client_secret = _resolve_static_client_secret(hosts[0])
+                if client_secret:
+                    static_response = {
+                        "client_id": client_id,
+                        "client_secret": client_secret,
+                        "token_endpoint_auth_method": "client_secret_basic",
+                        **common_response_fields,
+                    }
+                else:
+                    static_response = {
+                        "client_id": client_id,
+                        "token_endpoint_auth_method": "none",
+                        **common_response_fields,
+                    }
+                logger.info(
+                    f"DCR static-path: client={client_name!r} "
+                    f"hosts={sorted(set(hosts))} "
+                    f"auth={static_response['token_endpoint_auth_method']}"
+                )
+                return JSONResponse(static_response)
 
             # Dynamic-path — mutate DCR app in Zitadel
             dcr = _resolve_dcr_env()
@@ -511,7 +553,13 @@ class OdooMCPServer:
                 f"DCR dynamic-path: client={client_name!r} "
                 f"hosts={sorted(set(hosts))} uris={len(raw_uris)}"
             )
-            return JSONResponse({"client_id": dcr_client_id, **common_response_fields})
+            return JSONResponse(
+                {
+                    "client_id": dcr_client_id,
+                    "token_endpoint_auth_method": "none",
+                    **common_response_fields,
+                }
+            )
 
     @staticmethod
     def _build_oauth_settings():

--- a/tests/test_oauth_dcr.py
+++ b/tests/test_oauth_dcr.py
@@ -18,6 +18,7 @@ from mcp_server_odoo.server import (
     _DCRUpdateError,
     _resolve_dcr_env,
     _resolve_static_client_id,
+    _resolve_static_client_secret,
 )
 
 
@@ -122,6 +123,27 @@ class TestResolveStaticClientId:
     def test_unset_env_returns_empty(self, monkeypatch):
         monkeypatch.delenv("MCP_LECHAT_CLIENT_ID", raising=False)
         assert _resolve_static_client_id("callback.mistral.ai") == ""
+
+
+class TestResolveStaticClientSecret:
+    """Le Chat is the only confidential static client; everyone else is public."""
+
+    def test_lechat_returns_configured_secret(self, monkeypatch):
+        monkeypatch.setenv("MCP_LECHAT_CLIENT_SECRET", "shh-secret")
+        assert _resolve_static_client_secret("callback.mistral.ai") == "shh-secret"
+
+    def test_lechat_unset_returns_empty(self, monkeypatch):
+        monkeypatch.delenv("MCP_LECHAT_CLIENT_SECRET", raising=False)
+        assert _resolve_static_client_secret("callback.mistral.ai") == ""
+
+    def test_claude_is_public_client_no_secret(self, monkeypatch):
+        # Claude uses PKCE only — no secret env var, helper returns "".
+        monkeypatch.setenv("MCP_LECHAT_CLIENT_SECRET", "should-not-leak")
+        assert _resolve_static_client_secret("claude.ai") == ""
+        assert _resolve_static_client_secret("localhost") == ""
+
+    def test_unknown_host_returns_empty(self):
+        assert _resolve_static_client_secret("evil.com") == ""
 
 
 class TestResolveDcrEnv:


### PR DESCRIPTION
Follow-up to #21. Le Chat fails internally with **\"Missing oauth2 metadata secrets in oauth callback\"** because we returned no \`client_secret\` in DCR — but Le Chat is a confidential client.

## Why

Per Mistral's OAuth flow ([writeup](https://adriensieg.substack.com/p/how-can-you-securely-protect-your)), Le Chat sends \`token_endpoint_auth_method: \"client_secret_basic\"\` in DCR and authenticates at /token with both HTTP Basic + PKCE code_verifier. Without the secret it can't complete the callback.

## Changes

- New \`_resolve_static_client_secret(host)\` returning a secret only for \`callback.mistral.ai\` (from \`MCP_LECHAT_CLIENT_SECRET\` env).
- \`/register\` static-path branches on secret presence:
  - confidential (Le Chat) → \`client_secret\` + \`auth=client_secret_basic\`
  - public (Claude, localhost) → no secret + \`auth=none\` (unchanged)
- \`/.well-known/oauth-authorization-server\` advertises all three auth methods so clients can negotiate.

## Companion ops

- Zitadel \`mcp-lechat\` app needs \`authMethodType: BASIC\` (already done on prod via mgmt API).
- Prod \`MCP_LECHAT_CLIENT_SECRET\` must be set (separate admin-repo PR for docker-compose forwarding + actual env value).

## Tests

- 4 new unit tests in \`tests/test_oauth_dcr.py\` covering the new helper. All 29 DCR tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)