### PR TITLE
chore: align SERVER_VERSION with pyproject.toml (1.5.0)

### DIFF
--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -37,8 +37,8 @@ from .version_detect import detect_api_version
 # Set up logging
 logger = get_logger(__name__)
 
-# Server version
-SERVER_VERSION = "1.4.3"
+# Server version — keep in sync with pyproject.toml
+SERVER_VERSION = "1.5.0"
 GIT_COMMIT = os.environ.get("GIT_COMMIT", "unknown")
 _BUILD_ORIGIN = "pnl-mcp-7f3a"  # Pantalytics provenance tag
 


### PR DESCRIPTION
Drift fix: pyproject.toml was at 1.5.0, SERVER_VERSION still at 1.4.3. The runtime constant is what `server_info` reports to MCP clients.