### PR TITLE
ops: add session lifecycle middleware hook (no-op for self-hosters)

### DIFF
--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -857,6 +857,19 @@ class OdooMCPServer:
                     logger.warning("Admin panel not available (odoo-mcp-pro-admin not installed)")
                 logger.info("Admin panel mounted at /admin")
 
+            # Wrap with session lifecycle tracking (no-op without admin package).
+            # Filters by /mcp path so admin requests pass through untouched.
+            from .usage import SessionLifecycleMiddleware, track_event
+
+            asgi_app = SessionLifecycleMiddleware(asgi_app)
+            track_event(
+                "mcp_server_started",
+                properties={
+                    "git_commit": os.getenv("GIT_COMMIT", "unknown"),
+                    "multi_tenant": bool(database_url),
+                },
+            )
+
             import uvicorn
 
             config = uvicorn.Config(

--- a/mcp_server_odoo/usage.py
+++ b/mcp_server_odoo/usage.py
@@ -21,6 +21,16 @@ def track_event(event: str, distinct_id: str = "server", properties: Optional[di
     pass
 
 
+class SessionLifecycleMiddleware:
+    """No-op middleware. Install odoo-mcp-pro-admin for session lifecycle tracking."""
+
+    def __init__(self, app, path_prefix: str = "/mcp"):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        await self.app(scope, receive, send)
+
+
 class RateLimitExceeded(Exception):
     """Raised when a user exceeds their daily call limit."""
 


### PR DESCRIPTION
## Summary

Adds the call sites that allow the admin package's `SessionLifecycleMiddleware` to track MCP session start/end events — used to measure how often sessions drop during blue-green deploys (the "Session not found" error).

The actual telemetry logic lives in the private admin package. This PR only adds the hooks:

- `usage.py`: a no-op `SessionLifecycleMiddleware` fallback (passes through, no events).
- `server.py`: wraps the ASGI app with the middleware after admin mount, and fires a `mcp_server_started` event with `git_commit` + `multi_tenant` properties.

## Self-hoster impact

**None.** Without `odoo-mcp-pro-admin` installed, both `SessionLifecycleMiddleware` and `track_event` are no-ops — runtime is byte-for-byte unchanged from before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)