### PR TITLE
ci: drop ty type check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,6 @@ jobs:
     - name: Lint with Ruff
       run: |
         ruff check . --output-format=github
-    
-    - name: Type check with ty
-      continue-on-error: true  # Open-core layout: admin.* and UsageTracker are provided by the private package
-      run: |
-        ty check .
 
   test:
     name: Test Python ${{ matrix.python-version }}


### PR DESCRIPTION
## Why

The `ty` step has been generating false-positive failure emails on every push for weeks. Cause is structural: the repo is open-core and `server.py` / `tools.py` import modules and types provided by the private `odoo-mcp-pro-admin` package at runtime, which static analyzers like `ty` see as unresolved.

Replaces the `continue-on-error: true` workaround from #25 with a clean removal.

## Net coverage after this PR

Kept: `ruff format --check`, `ruff check`, full test matrix (3.10 / 3.11 / 3.12), integration tests, build.

Dropped: `ty check`. Real type errors in this codebase are caught by tests at runtime; the open-core layout fundamentally confuses static analysis.

## When to revisit

If we ever refactor so the public package is self-contained for static analysis (proper `try/except ImportError` guards + stub classes for the optional admin pieces), type-checking becomes useful again. Until then, the maintenance cost outweighs the signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)