### PR TITLE
fix: align __version__ + post-audit test cleanup

### DIFF
--- a/mcp_server_odoo/__init__.py
+++ b/mcp_server_odoo/__init__.py
@@ -1,6 +1,6 @@
 """MCP Server for Odoo - Model Context Protocol server for Odoo ERP systems."""
 
-__version__ = "1.2.1"
+__version__ = "1.5.0"
 __author__ = "Andrey Ivanov"
 __license__ = "MPL-2.0"
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -153,47 +153,31 @@ class TestAuthentication:
 
     @patch("urllib.request.urlopen")
     def test_authentication_fallback(self, mock_urlopen, config_both):
-        """Test fallback from API key to username/password."""
-        # Create connection with both auth methods
+        """Test fallback from MCP /auth/validate to standard XML-RPC.
+
+        When the MCP-specific endpoint returns 401, _authenticate_api_key
+        falls back to _authenticate_api_key_standard which calls common.authenticate
+        with the api_key in the password slot. The auth_method stays "api_key"
+        because that's literally what was used — this is NOT a fallback to
+        username/password auth (that path is covered by
+        test_authentication_fallback_in_standard_mode).
+        """
         conn = OdooConnection(config_both)
         conn._connected = True
 
-        # Mock failed API key response
+        # MCP endpoint returns 401 → triggers XML-RPC fallback
         mock_urlopen.side_effect = urllib.error.HTTPError(None, 401, "Unauthorized", {}, None)
 
-        # Mock successful password auth
+        # Standard XML-RPC accepts the api_key as password and returns a uid
         mock_common = Mock()
         mock_common.authenticate.return_value = 3
         conn._common_proxy = mock_common
 
-        # Authenticate - should fallback to password
         conn.authenticate("mcp")
 
-        # Verify authenticated (via standard XML-RPC API key fallback)
         assert conn.is_authenticated
         assert conn.uid == 3
         assert conn.auth_method == "api_key"
-
-    def test_authenticate_with_auto_database(self, connection_api_key):
-        """Test authentication with automatic database selection."""
-        # Mock database list to return the configured database
-        mock_db = Mock()
-        db_name = os.getenv("ODOO_DB")
-        mock_db.list.return_value = [db_name]
-        connection_api_key._db_proxy = mock_db
-
-        # Mock API key auth
-        with patch("urllib.request.urlopen") as mock_urlopen:
-            mock_response = MagicMock()
-            mock_response.read.return_value = json.dumps(
-                {"success": True, "data": {"valid": True, "user_id": 2}}
-            ).encode("utf-8")
-            mock_urlopen.return_value.__enter__.return_value = mock_response
-
-            # Authenticate without specifying database
-            connection_api_key.authenticate()
-
-            assert connection_api_key.database == db_name
 
     def test_authentication_state_cleared_on_disconnect(self, connection_api_key):
         """Test authentication state is cleared on disconnect."""

--- a/tests/test_database_discovery.py
+++ b/tests/test_database_discovery.py
@@ -170,7 +170,7 @@ class TestDatabaseDiscoveryIntegration:
         return OdooConfig(
             url=os.getenv("ODOO_URL", "http://localhost:8069"),
             api_key=os.getenv("ODOO_API_KEY"),
-            database=None,  # Let it auto-select
+            database=None,  # Remaining tests don't authenticate, only list/validate
         )
 
     def test_real_list_databases(self, real_config):

--- a/tests/test_package_structure.py
+++ b/tests/test_package_structure.py
@@ -31,11 +31,14 @@ class TestPackageStructure:
 
     def test_package_imports(self):
         """Test that the package can be imported."""
+        import re
+
         import mcp_server_odoo
 
-        # Check version
+        # Version exists and looks like semver — don't pin to a specific number
+        # (pinning means every release bump fails this test for nothing).
         assert hasattr(mcp_server_odoo, "__version__")
-        assert mcp_server_odoo.__version__ == "1.2.1"
+        assert re.match(r"^\d+\.\d+\.\d+", mcp_server_odoo.__version__)
 
         # Check main class
         assert hasattr(mcp_server_odoo, "OdooMCPServer")


### PR DESCRIPTION
Two follow-ups from the test-suite audit done after #27.

## Real fix
- \`mcp_server_odoo/__init__.py\` had \`__version__ = \"1.2.1\"\` while \`pyproject.toml\` is at \`1.5.0\`. \`a348c23\` aligned \`SERVER_VERSION\` but missed \`__version__\` — \`pip show\` and \`importlib.metadata\` reported the wrong number.

## Test cleanup
- Drop \`test_authenticate_with_auto_database\` — auto-select was removed in v1.2.1; the test only passed because the fixture carried \`ODOO_DB\` from env and the mocked \`_db_proxy.list\` was dead.
- Rewrite \`test_authentication_fallback\` docstring/comments. It actually tests the MCP→XML-RPC fallback (still using the api_key as password); not the api_key→password fallback (that's \`test_authentication_fallback_in_standard_mode\`). The audit flagged it as uncertain — disambiguated.
- Drop stale \"Let it auto-select\" comment in \`test_database_discovery.py\`.
- Relax \`test_package_imports\` version assertion from hardcoded \`\"1.2.1\"\` to a semver regex. Pinning means every release bump silently fails for nothing.

## Test plan
- [x] 26 tests pass locally (auth + discovery + package_structure)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)