### PR TITLE
fix: honor stored Odoo Login for xmlrpc + track server_info failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 
 ## [Unreleased]
 
+### Fixed
+- **XML-RPC username resolution**: `registry.get_connection` now reads `user_conn.odoo_login` (when set) and falls back to `user_conn.email`. Odoo authenticates against `res.users.login`, which can differ from the user's email (e.g. `login="admin"`); the previous behavior locked everyone to the sign-up email.
+- **`server_info` observability**: `_current_sub` is now set before the registry/rate-limit calls in `_get_user_context`, so when those raise and a tool catches the exception (notably `server_info`), usage tracking still attributes the event to the correct user instead of silently no-op'ing as `"stdio"`.
+
 ## [1.5.0] - 2026-04-28
 
 ### Added

--- a/mcp_server_odoo/registry.py
+++ b/mcp_server_odoo/registry.py
@@ -115,14 +115,16 @@ class ConnectionRegistry:
             f" (Odoo {server_version or 'unknown'})"
         )
 
-        # Create connection with detected API version
-        # For XML-RPC (Odoo 14-18), the Zitadel email is used as the Odoo login
-        # (API key auth requires both username and key as password)
+        # Create connection with detected API version.
+        # For XML-RPC (Odoo 14-18) Odoo authenticates against res.users.login,
+        # which can differ from the user's email (e.g. login="admin"). Prefer
+        # the explicitly stored Odoo Login when present; fall back to email.
+        odoo_login = getattr(user_conn, "odoo_login", None) or user_conn.email
         config = OdooConfig(
             url=user_conn.odoo_url,
             database=user_conn.odoo_db or None,
             api_key=user_conn.odoo_api_key,
-            username=user_conn.email if api_version == "xmlrpc" else None,
+            username=odoo_login if api_version == "xmlrpc" else None,
             api_version=api_version,
         )
 
@@ -161,7 +163,7 @@ class ConnectionRegistry:
                 f"Odoo URL: {user_conn.odoo_url}",
                 f"Odoo version: {server_version or 'unknown'}",
                 f"API mode: {api_version}",
-                f"Username: {user_conn.email}",
+                f"Username: {odoo_login}",
                 f"Database: {user_conn.odoo_db or 'not set'}",
             ]
 
@@ -169,8 +171,10 @@ class ConnectionRegistry:
             if "Authentication failed" in error_str:
                 if api_version == "xmlrpc":
                     hints.append(
-                        "Your Odoo login email must match your sign-up email. "
-                        "Check that your API key belongs to this user."
+                        "Odoo authenticates against res.users.login, which is not "
+                        "always your email. Check Settings -> Users -> your user -> "
+                        "Login in Odoo and enter that exact value as the Odoo Login "
+                        "on the setup page. Also confirm the API key belongs to that user."
                     )
                 else:
                     hints.append("Your API key may be invalid or expired. Regenerate it in Odoo.")

--- a/mcp_server_odoo/tools.py
+++ b/mcp_server_odoo/tools.py
@@ -114,13 +114,15 @@ class OdooToolHandler:
             if access_token is None:
                 raise ValidationError("No authentication token available")
             sub = access_token.client_id
+            # Set early so callers that catch downstream errors (e.g. server_info)
+            # can still emit usage/diagnostic events tied to the right user.
+            _current_sub.set(sub)
 
             # Check rate limit before doing any work
             if self.usage_tracker:
                 await self.usage_tracker.check_rate_limit(sub)
 
             cached = await self.registry.get_connection(sub)
-            _current_sub.set(sub)
             return cached.connection, cached.access_controller, sub
 
         # Stdio mode: use direct connection (no rate limiting)


### PR DESCRIPTION
## Summary
- `registry.get_connection` reads `user_conn.odoo_login` (when set) and falls back to `user_conn.email`. Odoo's XML-RPC authenticates against `res.users.login`, which is independent of the email field — users whose login is e.g. `admin` while their email is `michele@company.com` could never authenticate.
- `_get_user_context` sets `_current_sub` before the registry/rate-limit calls, so when those raise and `server_info` catches the exception, `_track_usage` still attributes the event to the right user instead of silently no-op'ing as `"stdio"`.

## Why
Customer ticket: connection saved + verified ✅ in admin panel, but every `mcp_tool_called server_info` call returned `Connection Status: ❌ Not connected`. PostHog showed 4 silent `connection_error / auth_failed / xmlrpc / odoo.sh` events. Reproducing with the stored credentials confirmed Odoo XML-RPC's `authenticate(db, user_email, api_key, {})` returned `False` — but `authenticate(db, "admin", api_key, {})` works. Login ≠ email is a real Odoo quirk; see [odoo/odoo#205635](https://github.com/odoo/odoo/issues/205635).

The `getattr(user_conn, "odoo_login", None)` access keeps the change backward-compatible with any self-hosted overlay that hasn't added the field.

## Companion change
The admin overlay (separate PR in `odoo-mcp-pro-admin`) adds the `odoo_login` column on `user_connections` and wires the setup form's "Odoo Login" field through to it. This OSS change is no-op until the admin overlay sets the field.

## Test plan
- [x] All 511 existing unit tests pass; ruff clean
- [ ] Post-deploy: existing connections continue to work (fallback to email)
- [ ] Post-deploy: customer re-saves with explicit `Odoo Login = "admin"` (or actual `res.users.login`), runs "Odoo MCP server info" — returns Connected ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)