### PR TITLE
feat: post_message tool + communications skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 
 ## [Unreleased]
 
+### Added
+- **`post_message`** tool: post chatter messages and notes via the API, equivalent to clicking "Send Message" / "Log Note" in the Odoo UI. Sends synchronously within the request (no email-queue cron wait); returns the `mail.message` id, per-recipient `mail.notification` rows, and — on Odoo with `pan_outlook_pro` — the Microsoft Graph `internetMessageId` for thread reconstruction.
+- **`communications`** skill: how-to for chatter API (note vs message, attachments, followers, activities) plus vanilla-vs-`pan_outlook_pro` behavioral differences. Companion to `post_message`.
+- **Le Chat (Mistral) connector support**: per-AI Zitadel app routing so Le Chat can sign in via OAuth. Le Chat is a confidential client, so `/register` returns `client_secret` for it.
+
 ### Fixed
 - **XML-RPC username resolution**: `registry.get_connection` now reads `user_conn.odoo_login` (when set) and falls back to `user_conn.email`. Odoo authenticates against `res.users.login`, which can differ from the user's email (e.g. `login="admin"`); the previous behavior locked everyone to the sign-up email.
 - **`server_info` observability**: `_current_sub` is now set before the registry/rate-limit calls in `_get_user_context`, so when those raise and a tool catches the exception (notably `server_info`), usage tracking still attributes the event to the correct user instead of silently no-op'ing as `"stdio"`.

--- a/mcp_server_odoo/connection_protocol.py
+++ b/mcp_server_odoo/connection_protocol.py
@@ -75,3 +75,27 @@ class OdooConnectionProtocol(Protocol):
     def check_access_rights(self, model: str, operation: str) -> bool: ...
 
     def get_server_version(self) -> Optional[Dict[str, Any]]: ...
+
+    def call_method(
+        self,
+        model: str,
+        method: str,
+        ids: Optional[List[int]] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Call an arbitrary ORM method on a model or recordset.
+
+        Transport-agnostic wrapper around `execute_kw` (XML-RPC) /
+        `_call` (JSON/2). Use for non-CRUD methods like `message_post`,
+        `action_confirm`, `activity_schedule`, etc.
+
+        Args:
+            model: Odoo model name.
+            ids: Recordset ids — pass for record-level methods. Omit
+                for class-level (`@api.model`) methods.
+            **kwargs: Keyword arguments forwarded to the Odoo method.
+
+        Returns:
+            Whatever the Odoo method returns.
+        """
+        ...

--- a/mcp_server_odoo/odoo_connection.py
+++ b/mcp_server_odoo/odoo_connection.py
@@ -711,6 +711,20 @@ class OdooConnection:
         """
         return self.execute_kw(model, method, list(args), {})
 
+    def call_method(
+        self,
+        model: str,
+        method: str,
+        ids: Optional[List[int]] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Transport-agnostic recordset method call (XML-RPC backend).
+
+        See `OdooConnectionProtocol.call_method` for semantics.
+        """
+        args = [list(ids)] if ids is not None else []
+        return self.execute_kw(model, method, args, kwargs)
+
     def execute_kw(self, model: str, method: str, args: List[Any], kwargs: Dict[str, Any]) -> Any:
         """Execute an operation on an Odoo model with keyword arguments.
 

--- a/mcp_server_odoo/odoo_json2_connection.py
+++ b/mcp_server_odoo/odoo_json2_connection.py
@@ -527,6 +527,24 @@ class OdooJSON2Connection:
                 return True
             return False
 
+    def call_method(
+        self,
+        model: str,
+        method: str,
+        ids: Optional[List[int]] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Transport-agnostic recordset method call (JSON/2 backend).
+
+        See `OdooConnectionProtocol.call_method` for semantics. JSON/2
+        passes the recordset as `ids` in the request body.
+        """
+        body: Dict[str, Any] = {}
+        if ids is not None:
+            body["ids"] = list(ids)
+        body.update(kwargs)
+        return self._call(model, method, **body)
+
     def get_server_version(self) -> Optional[Dict[str, Any]]:
         """Get Odoo server version information.
 

--- a/mcp_server_odoo/schemas.py
+++ b/mcp_server_odoo/schemas.py
@@ -145,6 +145,38 @@ class DeleteResult(BaseModel):
     message: str = Field(description="Human-readable success message")
 
 
+# --- Post Message (chatter) ---
+
+
+class PostMessageNotification(BaseModel):
+    """One mail.notification row created by a chatter post."""
+
+    partner_id: int = Field(description="res.partner id of the recipient")
+    partner_name: str = Field(description="Display name of the recipient")
+    type: str = Field(description="notification_type — 'inbox' or 'email'")
+    status: str = Field(description="notification_status — 'sent', 'exception', 'ready', etc.")
+    failure_reason: Optional[str] = Field(default=None, description="Failure detail when status is 'exception'")
+
+
+class PostMessageResult(BaseModel):
+    """Result of posting a chatter message via mail.thread.message_post."""
+
+    success: bool = Field(description="Whether the post succeeded")
+    message_id: int = Field(description="ID of the created mail.message")
+    subtype: Optional[str] = Field(default=None, description="Subtype name — e.g. 'Discussions' (mt_comment) or 'Note' (mt_note)")
+    attachment_count: int = Field(default=0, description="Number of attachments linked to the message")
+    notifications: List[PostMessageNotification] = Field(
+        default_factory=list,
+        description="Per-recipient delivery rows. Empty for silent notes without explicit partner_ids.",
+    )
+    outlook_pro_message_id: Optional[str] = Field(
+        default=None,
+        description="x_microsoft_message_id when pan_outlook_pro is installed and the send went via Graph",
+    )
+    record_url: str = Field(description="Direct URL to the record in Odoo")
+    message: str = Field(description="Human-readable summary")
+
+
 # --- Bulk Operations ---
 
 

--- a/mcp_server_odoo/schemas.py
+++ b/mcp_server_odoo/schemas.py
@@ -155,7 +155,9 @@ class PostMessageNotification(BaseModel):
     partner_name: str = Field(description="Display name of the recipient")
     type: str = Field(description="notification_type — 'inbox' or 'email'")
     status: str = Field(description="notification_status — 'sent', 'exception', 'ready', etc.")
-    failure_reason: Optional[str] = Field(default=None, description="Failure detail when status is 'exception'")
+    failure_reason: Optional[str] = Field(
+        default=None, description="Failure detail when status is 'exception'"
+    )
 
 
 class PostMessageResult(BaseModel):
@@ -163,8 +165,13 @@ class PostMessageResult(BaseModel):
 
     success: bool = Field(description="Whether the post succeeded")
     message_id: int = Field(description="ID of the created mail.message")
-    subtype: Optional[str] = Field(default=None, description="Subtype name — e.g. 'Discussions' (mt_comment) or 'Note' (mt_note)")
-    attachment_count: int = Field(default=0, description="Number of attachments linked to the message")
+    subtype: Optional[str] = Field(
+        default=None,
+        description="Subtype name — e.g. 'Discussions' (mt_comment) or 'Note' (mt_note)",
+    )
+    attachment_count: int = Field(
+        default=0, description="Number of attachments linked to the message"
+    )
     notifications: List[PostMessageNotification] = Field(
         default_factory=list,
         description="Per-recipient delivery rows. Empty for silent notes without explicit partner_ids.",

--- a/mcp_server_odoo/tools.py
+++ b/mcp_server_odoo/tools.py
@@ -40,6 +40,7 @@ from .schemas import (
     FieldSelectionMetadata,
     ImportResult,
     ModelsResult,
+    PostMessageResult,
     RecordResult,
     ResourceTemplatesResult,
     SearchResult,
@@ -940,6 +941,70 @@ class OdooToolHandler:
             self._track_usage(_current_sub.get(), "set_binary_field")
             return BinaryFieldResult(**result)
 
+        # --- Chatter: post_message ---
+
+        @self.app.tool(
+            title="Post Chatter Message (Send Message / Log Note)",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,  # mt_comment sends real email; mt_note may also if partner_ids set
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+        async def post_message(
+            model: str,
+            record_id: int,
+            body: str,
+            subject: Optional[str] = None,
+            partner_ids: Optional[List[int]] = None,
+            attachment_ids: Optional[List[int]] = None,
+            subtype_xmlid: str = "mail.mt_comment",
+            cc: Optional[str] = None,
+        ) -> PostMessageResult:
+            """Post a message in the chatter of any thread-enabled Odoo record.
+
+            Equivalent to clicking 'Send Message' (subtype=mt_comment, default)
+            or 'Log Note' (subtype=mt_note) in the Odoo UI. Sends synchronously
+            within the same request — no waiting on the email queue cron.
+
+            Args:
+                model: Odoo model with chatter enabled — 'res.partner', 'crm.lead',
+                    'sale.order', 'account.move', 'helpdesk.ticket', etc.
+                record_id: ID of the record to post on.
+                body: HTML body of the message. Plain strings are HTML-escaped by Odoo.
+                subject: Optional subject line. Defaults to the record's display_name
+                    when omitted on a non-note message.
+                partner_ids: Explicit recipients (res.partner ids). Notifies them on
+                    top of subscribed followers. NB: setting this on a note (mt_note)
+                    still creates mail.notification + mail.mail for these partners.
+                attachment_ids: ir.attachment ids to link to the message. Pre-create
+                    via create_record on ir.attachment with {name, datas, res_model,
+                    res_id} — this is required because inline byte transport over
+                    XML-RPC fails.
+                subtype_xmlid: 'mail.mt_comment' (default — sends email to followers)
+                    or 'mail.mt_note' (silent internal note, hidden from portal users).
+                cc: Comma-separated extra emails to notify (Odoo v19+ only).
+                    On older Odoos this raises a clear error.
+
+            Returns:
+                Posted mail.message details including per-recipient delivery state
+                (mail.notification rows) and, if pan_outlook_pro is installed and the
+                send went via Microsoft Graph, the Outlook message-id.
+            """
+            result = await self._handle_post_message_tool(
+                model=model,
+                record_id=record_id,
+                body=body,
+                subject=subject,
+                partner_ids=partner_ids,
+                attachment_ids=attachment_ids,
+                subtype_xmlid=subtype_xmlid,
+                cc=cc,
+            )
+            self._track_usage(_current_sub.get(), "post_message")
+            return PostMessageResult(**result)
+
     async def _handle_search_tool(
         self,
         model: str,
@@ -1819,6 +1884,166 @@ class OdooToolHandler:
             logger.error(f"Error in set_binary_field tool: {e}")
             sanitized_msg = ErrorSanitizer.sanitize_message(str(e))
             raise ValidationError(f"Failed to set binary field: {sanitized_msg}") from e
+
+    async def _call_record_method(
+        self,
+        connection: OdooConnectionProtocol,
+        model: str,
+        record_ids: List[int],
+        method: str,
+        kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Invoke a method on a recordset via the transport-agnostic call_method.
+
+        Generic helper for tools that wrap an Odoo recordset method
+        (`record.foo(...)` rather than CRUD). Works on both XML-RPC
+        and JSON/2 transports.
+
+        Future tools (post_invoice, confirm_sale_order, etc.) reuse this.
+        """
+        return connection.call_method(model, method, ids=list(record_ids), **(kwargs or {}))
+
+    async def _handle_post_message_tool(
+        self,
+        model: str,
+        record_id: int,
+        body: str,
+        subject: Optional[str] = None,
+        partner_ids: Optional[List[int]] = None,
+        attachment_ids: Optional[List[int]] = None,
+        subtype_xmlid: str = "mail.mt_comment",
+        cc: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Handle post_message tool request."""
+        try:
+            connection, access_controller, sub = await self._get_user_context()
+            with perf_logger.track_operation("tool_post_message", model=model):
+                # Posting to chatter requires write access on the model
+                access_controller.validate_model_access(model, "write")
+
+                if not connection.is_authenticated:
+                    raise ValidationError("Not authenticated with Odoo")
+
+                if not body or not body.strip():
+                    raise ValidationError("body is required and cannot be empty")
+
+                # Verify record exists
+                existing = connection.read(model, [record_id], ["id"])
+                if not existing:
+                    raise NotFoundError(f"Record not found: {model} with ID {record_id}")
+
+                # Build kwargs for message_post — only include fields the user set,
+                # so we don't override Odoo's own defaults (e.g. subject from display_name).
+                kwargs: Dict[str, Any] = {
+                    "body": body,
+                    "message_type": "comment",
+                    "subtype_xmlid": subtype_xmlid,
+                }
+                if subject is not None:
+                    kwargs["subject"] = subject
+                if partner_ids:
+                    kwargs["partner_ids"] = list(partner_ids)
+                if attachment_ids:
+                    kwargs["attachment_ids"] = list(attachment_ids)
+                if cc:
+                    # Odoo v19+ only — older Odoos raise:
+                    # ValueError: Those values are not supported when posting or notifying: outgoing_email_to
+                    kwargs["outgoing_email_to"] = cc
+
+                raw = await self._call_record_method(
+                    connection, model, [record_id], "message_post", kwargs
+                )
+                # message_post returns the new mail.message id; some transports
+                # wrap singletons in a list — normalize.
+                if isinstance(raw, list):
+                    if not raw:
+                        raise ValidationError("message_post returned empty result")
+                    message_id = raw[0]
+                else:
+                    message_id = raw
+                if not isinstance(message_id, int):
+                    raise ValidationError(f"Unexpected message_post return: {raw!r}")
+
+                # Read message back for subtype/attachment summary
+                msg_fields = ["subtype_id", "attachment_ids"]
+                # x_microsoft_message_id only exists when pan_outlook_pro is installed
+                outlook_field = "x_microsoft_message_id"
+                try:
+                    available = connection.fields_get(
+                        "mail.message", [outlook_field], allfields=False
+                    )
+                except TypeError:
+                    available = connection.fields_get("mail.message", [outlook_field])
+                except Exception:
+                    available = {}
+                if outlook_field in (available or {}):
+                    msg_fields.append(outlook_field)
+
+                msg_rows = connection.read("mail.message", [message_id], msg_fields)
+                msg = msg_rows[0] if msg_rows else {}
+                subtype_pair = msg.get("subtype_id")
+                subtype_name = subtype_pair[1] if isinstance(subtype_pair, list) and len(subtype_pair) > 1 else None
+                attachments = msg.get("attachment_ids") or []
+                outlook_msg_id = msg.get(outlook_field) if outlook_field in msg_fields else None
+                if outlook_msg_id is False:
+                    outlook_msg_id = None
+
+                # Read notifications fan-out
+                notif_rows = connection.search_read(
+                    "mail.notification",
+                    [("mail_message_id", "=", message_id)],
+                    ["res_partner_id", "notification_type", "notification_status", "failure_reason"],
+                )
+                notifications: List[Dict[str, Any]] = []
+                for n in notif_rows:
+                    p = n.get("res_partner_id") or [None, ""]
+                    notifications.append({
+                        "partner_id": p[0] if isinstance(p, list) else None,
+                        "partner_name": p[1] if isinstance(p, list) and len(p) > 1 else "",
+                        "type": n.get("notification_type") or "",
+                        "status": n.get("notification_status") or "",
+                        "failure_reason": n.get("failure_reason") or None,
+                    })
+
+                base_url = (
+                    getattr(connection, "_base_url", None)
+                    or (self.config.url if self.config else "")
+                ).rstrip("/")
+                record_url = f"{base_url}/web#id={record_id}&model={model}&view_type=form"
+
+                send_count = sum(1 for n in notifications if n["status"] == "sent")
+                fail_count = sum(1 for n in notifications if n["status"] == "exception")
+                summary_bits = [f"posted mail.message {message_id}"]
+                if notifications:
+                    summary_bits.append(
+                        f"{len(notifications)} notification(s): {send_count} sent, {fail_count} failed"
+                    )
+                if outlook_msg_id:
+                    summary_bits.append("sent via Microsoft Graph")
+
+                return {
+                    "success": True,
+                    "message_id": message_id,
+                    "subtype": subtype_name,
+                    "attachment_count": len(attachments),
+                    "notifications": notifications,
+                    "outlook_pro_message_id": outlook_msg_id,
+                    "record_url": record_url,
+                    "message": "; ".join(summary_bits),
+                }
+
+        except ValidationError:
+            raise
+        except NotFoundError as e:
+            raise ValidationError(str(e)) from e
+        except AccessControlError as e:
+            raise ValidationError(f"Access denied: {e}") from e
+        except OdooConnectionError as e:
+            raise ValidationError(f"Connection error: {e}") from e
+        except Exception as e:
+            logger.error(f"Error in post_message tool: {e}")
+            sanitized_msg = ErrorSanitizer.sanitize_message(str(e))
+            raise ValidationError(f"Failed to post message: {sanitized_msg}") from e
 
 
 def register_tools(

--- a/mcp_server_odoo/tools.py
+++ b/mcp_server_odoo/tools.py
@@ -1982,7 +1982,11 @@ class OdooToolHandler:
                 msg_rows = connection.read("mail.message", [message_id], msg_fields)
                 msg = msg_rows[0] if msg_rows else {}
                 subtype_pair = msg.get("subtype_id")
-                subtype_name = subtype_pair[1] if isinstance(subtype_pair, list) and len(subtype_pair) > 1 else None
+                subtype_name = (
+                    subtype_pair[1]
+                    if isinstance(subtype_pair, list) and len(subtype_pair) > 1
+                    else None
+                )
                 attachments = msg.get("attachment_ids") or []
                 outlook_msg_id = msg.get(outlook_field) if outlook_field in msg_fields else None
                 if outlook_msg_id is False:
@@ -1992,18 +1996,25 @@ class OdooToolHandler:
                 notif_rows = connection.search_read(
                     "mail.notification",
                     [("mail_message_id", "=", message_id)],
-                    ["res_partner_id", "notification_type", "notification_status", "failure_reason"],
+                    [
+                        "res_partner_id",
+                        "notification_type",
+                        "notification_status",
+                        "failure_reason",
+                    ],
                 )
                 notifications: List[Dict[str, Any]] = []
                 for n in notif_rows:
                     p = n.get("res_partner_id") or [None, ""]
-                    notifications.append({
-                        "partner_id": p[0] if isinstance(p, list) else None,
-                        "partner_name": p[1] if isinstance(p, list) and len(p) > 1 else "",
-                        "type": n.get("notification_type") or "",
-                        "status": n.get("notification_status") or "",
-                        "failure_reason": n.get("failure_reason") or None,
-                    })
+                    notifications.append(
+                        {
+                            "partner_id": p[0] if isinstance(p, list) else None,
+                            "partner_name": p[1] if isinstance(p, list) and len(p) > 1 else "",
+                            "type": n.get("notification_type") or "",
+                            "status": n.get("notification_status") or "",
+                            "failure_reason": n.get("failure_reason") or None,
+                        }
+                    )
 
                 base_url = (
                     getattr(connection, "_base_url", None)

--- a/skills/README.md
+++ b/skills/README.md
@@ -59,6 +59,7 @@ odoo_modules_any: [sale_management, crm]
 | `automating` | Automated actions, cron jobs, triggers |
 | `cleaning` | Deduplicate, enrich, fix data quality |
 | `permissions` | Groups, access rights, record rules |
+| `communications` | Chatter messages, notes, activities, attachments, followers (mail.thread API) |
 
 ### Flagship skills
 

--- a/skills/communications/REFERENCE.md
+++ b/skills/communications/REFERENCE.md
@@ -1,0 +1,308 @@
+# Communications — Reference
+
+Deep-dive companion to [SKILL.md](SKILL.md). Load this when you need
+exact field names, signatures, or stock xmlids.
+
+## `mail.thread.message_post` signature
+
+```python
+record.message_post(
+    body='',                    # str | Markup — HTML, plain str gets escaped
+    subject=None,
+    message_type='notification',# email | comment | email_outgoing | notification | auto_comment | out_of_office
+                                # NOT 'user_notification' (use message_notify)
+    email_from=None,            # override visible sender
+    author_id=None,             # res.partner id of author
+    parent_id=False,            # mail.message id to thread under
+    subtype_xmlid=None,         # 'mail.mt_note' (default) | 'mail.mt_comment' | 'mail.mt_activities'
+    subtype_id=False,           # numeric alternative to subtype_xmlid
+    partner_ids=None,           # [partner_id, …] — extra recipients
+    outgoing_email_to=False,    # comma-separated emails (Odoo v19)
+    incoming_email_to=False,    # comma-separated; already-notified emails
+    incoming_email_cc=False,
+    attachments=None,           # [(name, raw_bytes), …] OR [(name, raw_bytes, info_dict), …]
+    attachment_ids=None,        # [ir.attachment id, …] — alternative to attachments=
+    body_is_html=False,         # only for RPC: forces str body to HTML
+    **kwargs                    # extra mail.message fields, or notify kwargs
+)
+```
+
+Returns the created `mail.message` record.
+
+`subject` defaults to record `display_name` for non-note message types.
+
+## `mail.thread.message_notify` signature
+
+Same as `message_post` minus `message_type` (always `user_notification`),
+`parent_id`, `outgoing_email_to`. Plus `model` and `res_id` so you can
+notify without a record. **Notification only** — does not appear in the
+record's chatter.
+
+## `mail.activity.mixin.activity_schedule` signature
+
+```python
+record.activity_schedule(
+    act_type_xmlid='',          # 'mail.mail_activity_data_call', etc.
+    date_deadline=None,         # date (not datetime); defaults to today
+    summary='',
+    note='',
+    user_id=...,                # responsible user (default: activity_type.default_user_id)
+    **act_values                # any other mail.activity field
+)
+```
+
+Stock activity types (defined in `mail/data/mail_activity_type_data.xml`):
+
+| xmlid | Name | Category | Default delay |
+|---|---|---|---|
+| `mail.mail_activity_data_email` | Email | default | 0 |
+| `mail.mail_activity_data_call` | Call | phonecall | 2 days |
+| `mail.mail_activity_data_meeting` | Meeting | default | 0 |
+| `mail.mail_activity_data_todo` | To-Do | default | 5 days |
+| `mail.mail_activity_data_upload_document` | Document | upload_file | 5 days |
+| `mail.mail_activity_data_warning` | Exception | default | 0 (inactive by default) |
+
+`category='upload_file'` triggers a file uploader in the UI and
+auto-marks done on upload. `category='phonecall'` opens click-to-dial
+where applicable.
+
+Mark done: `record.activity_feedback(act_type_xmlids, feedback='...')`
+or `activity.action_done()` on the `mail.activity` record.
+
+## `mail.message` — full field cheat sheet
+
+Content
+- `subject` (Char), `body` (Html, sanitized), `preview` (Char, computed)
+- `attachment_ids` (M2M `ir.attachment`)
+- `parent_id` / `child_ids` (threading)
+
+Related document
+- `model` (Char), `res_id` (Many2oneReference), `record_name` (computed)
+- `record_alias_domain_id`, `record_company_id`
+
+Characteristics
+- `message_type` (Selection — see above)
+- `subtype_id` (M2O `mail.message.subtype`)
+- `mail_activity_type_id` (when posted by activity completion)
+- `is_internal` (Bool — hide from portal/public independent of subtype)
+
+Origin
+- `author_id` (M2O `res.partner`), `author_guest_id` (M2O `mail.guest`)
+- `email_from` (Char — used when no matching partner)
+
+Recipients
+- `partner_ids` (M2M `res.partner`)
+- `incoming_email_to` / `incoming_email_cc` / `outgoing_email_to`
+- `notified_partner_ids` (computed from notifications, may decay via gc)
+- `notification_ids` (O2M `mail.notification`)
+
+UI
+- `starred_partner_ids`, `pinned_at`, `starred`
+
+Tracking
+- `tracking_value_ids` (O2M `mail.tracking.value`) — auto-populated on tracked-field writes
+
+Mail gateway
+- `message_id` (Char — the RFC `Message-ID:` header)
+- `reply_to`, `reply_to_force_new`
+- `mail_server_id` (M2O `ir.mail_server`)
+- `email_layout_xmlid`, `email_add_signature`
+- `mail_ids` (O2M `mail.mail`)
+
+## `mail.message.subtype` — the three stock subtypes
+
+Defined in `mail/data/mail_message_subtype_data.xml`:
+
+| xmlid | name | internal | default | Use |
+|---|---|---|---|---|
+| `mail.mt_comment` | Discussions | False | True | Real message to followers (sends email) |
+| `mail.mt_note` | Note | True | False | Internal note (no email, hidden from portal) |
+| `mail.mt_activities` | Activities | True | False | Auto-posted when activities are completed |
+
+Apps add their own model-scoped subtypes (e.g. `sale.mt_order_confirmed`,
+`crm.mt_lead_won`). Followers subscribe to subtypes; matching subtypes
+on a posted message determine who gets notified.
+
+## `mail.followers`
+
+| Field | Notes |
+|---|---|
+| `res_model`, `res_id` | What is being followed |
+| `partner_id` | Always a partner — never a user |
+| `subtype_ids` | M2M of subscribed `mail.message.subtype` |
+
+To make a user follow: subscribe their `partner_id`.
+
+## `mail.notification`
+
+Per-recipient delivery row created for each follower notified by a message.
+
+| Field | Values |
+|---|---|
+| `notification_type` | `inbox`, `email`, `sms`, `snail`, `web_push` |
+| `notification_status` | `ready`, `process`, `pending`, `sent`, `bounce`, `exception`, `canceled` |
+| `failure_type` | populated on bounce/exception |
+| `is_read` | inbox read state |
+
+User preference at `res.users.notification_type` decides inbox vs email.
+
+## `ir.attachment` — relevant fields
+
+| Field | Notes |
+|---|---|
+| `name` | Filename |
+| `datas` | Base64-encoded content |
+| `raw` | Binary content (alternative to `datas`) |
+| `mimetype` | Auto-detected if omitted |
+| `res_model`, `res_id` | Owning record (set so attachment appears in the record's Documents tab) |
+| `public` | If True, accessible without auth via URL |
+
+When passed as `attachments=[(name, content)]` to `message_post`, content
+is **raw bytes**, not base64. Internally Odoo creates the `ir.attachment`
+with `res_model` / `res_id` matching the chatter record.
+
+**XML-RPC caveat**: bytes sent via XML-RPC arrive on the server as
+`xmlrpc.client.Binary`, not `bytes`. Odoo's
+`mail_thread._process_attachments_for_post` then calls
+`base64.b64encode(content)` and crashes with
+`TypeError: a bytes-like object is required, not 'Binary'`. **Over
+XML-RPC, always pre-create `ir.attachment` and pass `attachment_ids=[id]`.**
+JSON-RPC and JSON/2 (Odoo 19) deserialize binary differently and may
+accept the inline form — confirm before relying on it.
+
+## Detecting Outlook Pro
+
+Probe in this order:
+
+1. `ir.module.module` search `[('name','=','pan_outlook_pro'),('state','=','installed')]`
+2. If `ir.module.module` access is restricted, check field existence:
+   `ir.model.fields` search `[('model','=','mail.message'),('name','=','x_microsoft_message_id')]`
+3. Or check model existence: `ir.model` search `[('model','=','x_microsoft.mailbox')]`
+
+### Three install stages — pick which one before predicting send behavior
+
+```python
+mailbox_count_total  = env['x_microsoft.mailbox'].with_context(active_test=False).search_count([])
+mailbox_count_active = env['x_microsoft.mailbox'].search_count([])
+```
+
+| Stage | total | active | Outbound `mail.mail.send()` lands at |
+|---|---|---|---|
+| Installed only | 0 | 0 | Standard SMTP — falls onto the `[Outlook Pro] SMTP Disabled` placeholder server (host unresolvable) → `state=exception`, `failure_reason: "-2\nName or service not known"` |
+| Configured, none active | ≥1 | 0 | `state=cancel` (silently dropped) |
+| Configured + active mailbox + user has token | ≥1 | ≥1 | Microsoft Graph (`x_microsoft_message_id` populated on success) |
+
+The fallback logic is in `pan_outlook_pro/models/mail_mail.py` `send()`.
+A "DNS error" right after a fresh install means stage 1, not a real
+SMTP problem.
+
+### Other install effects
+
+- `ir.mail_server`: post-init hook sets `active=False` on every existing
+  row, then loads one own placeholder named `[Outlook Pro] SMTP Disabled`
+  with `active=True`. **Do not interpret this as "SMTP is configured"** —
+  the placeholder is intentionally unusable.
+- `mail.message` gains `x_microsoft_message_id` and `x_microsoft_conversation_id`
+  (both indexed). Module-managed; don't write from the MCP.
+- `x_microsoft.mailbox` lists configured mailboxes. UI "Send From" =
+  `mail.compose.message.x_microsoft_send_from_id`; default mailbox per
+  user via `res.users.x_microsoft_default_mailbox_id`.
+- A new cron `Microsoft Graph: Fetch Incoming Mail` runs every **1 min**
+  (inbound only — outbound still uses `Mail: Email Queue Manager`,
+  default 1 hour).
+- Mass-mailing emails (`mailing.mailing`-driven, e.g. Brevo campaigns)
+  are explicitly excluded from the Graph route and continue through
+  standard SMTP, even when Outlook Pro is fully configured.
+
+## `ir.mail_server` (vanilla outbound config)
+
+Fields the API can inspect to understand current outbound setup:
+
+| Field | Notes |
+|---|---|
+| `name`, `from_filter` | Used to pick which server handles which `email_from` |
+| `smtp_host`, `smtp_port`, `smtp_encryption` | Connection details |
+| `smtp_user`, `smtp_pass` | Credentials |
+| `active` | False on Outlook Pro install |
+| `sequence` | Server selection priority |
+
+## `mail.alias` (inbound routing)
+
+| Field | Notes |
+|---|---|
+| `alias_name` + `alias_domain_id` | Local part + domain — together form the address |
+| `alias_model_id` | Target model (e.g. `helpdesk.ticket`, `crm.lead`) |
+| `alias_defaults` | Python literal dict of field defaults applied to `message_new()` |
+| `alias_contact` | `everyone` / `partners` / `followers` — who is allowed to post |
+| `alias_force_thread_id` | Always post to this record id, never create new |
+
+Both vanilla (MX → Odoo `mailgateway`) and Outlook Pro (Graph poll →
+processor) feed inbound mail through `mail.alias` for routing.
+
+## `mail.template` — sending a templated email
+
+```python
+template = env.ref('module.template_xmlid')
+template.send_mail(
+    record_id,
+    force_send=True,           # send synchronously (default: queue)
+    email_values={             # override on resulting mail.mail
+        'email_to': '...',
+        'attachment_ids': [...],
+    },
+)
+```
+
+`send_mail` returns the `mail.mail` id. Templates QWeb-render `body_html`,
+`subject`, `email_from`, `email_to`, etc. with the record in context.
+
+## Outbound flow recap
+
+```
+message_post(subtype=mt_comment)
+  └─ creates mail.message
+       └─ _notify_thread()
+            ├─ for inbox followers → mail.notification (notification_type='inbox')
+            └─ for email followers → mail.notification (notification_type='email')
+                 └─ mail.mail row created
+                      └─ synchronously sent in same request
+                         (force_send=True default in _notify_thread_by_email)
+                          ├─ success → state='sent' → row deleted (auto_delete=True)
+                          ├─ failure → state='exception' (NOT retried by cron)
+                          └─ skipped → state='outgoing'
+                                       (picked up by Mail: Email Queue Manager,
+                                        default interval 1 hour)
+                              ├─ vanilla: ir.mail_server → SMTP
+                              └─ Outlook Pro: branches on x_microsoft.mailbox
+                                  (see "Three install stages" above)
+```
+
+**Key consequences:**
+
+- After `message_post`, the `mail.mail` row may already be gone
+  (auto_delete on success). To audit "what was sent", read
+  `mail.notification` rows on the message.
+- An exception is sticky: re-trigger via `mail.mail.action_send()` or
+  recreate the message. The cron will not retry exceptions.
+- To force-send queued mails from the API:
+  ```python
+  env.ref('mail.ir_cron_mail_scheduler_action').method_direct_trigger()
+  # or send specific rows synchronously:
+  env['mail.mail'].browse([id1, id2]).send()
+  ```
+
+## What auto-creates messages without you calling message_post
+
+- **Tracked fields** — writing a tracked field on a `mail.thread` record
+  posts a system message with `tracking_value_ids`. Don't post a
+  duplicate "I changed X to Y" message.
+- **Stage transitions** — many models (CRM, Sales, Project) post
+  module-specific subtype messages on stage changes.
+- **Activity completion** — `activity.action_done()` posts a
+  `mt_activities`-subtype message.
+- **Inbound email** — gateway / Outlook Pro processor calls
+  `message_new()` or `message_update()` which posts the email body.
+- **Order confirmations / invoice posting** — workflow methods often post.
+
+When automating, read the chatter to verify what already exists before
+adding your own message.

--- a/skills/communications/SKILL.md
+++ b/skills/communications/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: communications
+description: Post messages and notes in Odoo chatter, schedule activities, attach files, and manage followers via the external API. Use when the user wants to log a call, leave an internal note, send an email through Odoo, schedule a follow-up, or add an attachment to any record.
+triggers: [chatter, message, note, log note, message_post, activity, follow-up, follower, subscribe, attachment, email, mail, send, schedule activity]
+odoo_modules_any: [mail]
+---
+
+# Communications
+
+How to talk to people through Odoo: post in chatter, send email, schedule
+activities, manage followers and attachments — via the external API
+(XML-RPC / `mcp_server_odoo`).
+
+For exact field lists, full method signatures, stock activity-type
+xmlids and the outbound-flow trace, see [REFERENCE.md](REFERENCE.md).
+
+Almost every business model in Odoo (`res.partner`, `crm.lead`,
+`sale.order`, `purchase.order`, `account.move`, `helpdesk.ticket`,
+`project.task`, …) inherits the `mail.thread` mixin. If a model has a
+chatter in the UI, it has chatter via the API.
+
+## Note vs message — the one decision that matters
+
+| | Internal note | Message |
+|---|---|---|
+| Subtype xmlid | `mail.mt_note` | `mail.mt_comment` |
+| Visible to | Internal users only | Followers (incl. the customer) |
+| Notifies followers? | **No** — internal subtype, followers' subtype filter drops it | **Yes** — followers with the subtype get notified |
+| Use for | "Called customer, will follow up Friday" | Replying to a customer thread |
+
+If you call `message_post` without `subtype_xmlid`, Odoo defaults to
+`mail.mt_note` — silent internal note as far as *followers* are
+concerned.
+
+**Email-vs-note is not just the subtype.** Whether email actually goes
+out depends on three things, in order:
+
+1. **Subtype** — `mt_comment` fans out to followers whose subscription
+   matches; `mt_note` does not.
+2. **Explicit `partner_ids`** — anything in `partner_ids` gets a
+   `mail.notification` regardless of subtype. *This includes notes.*
+   `message_post(subtype_xmlid='mail.mt_note', partner_ids=[X])`
+   creates a `mail.notification` + `mail.mail` for X. Treat
+   `partner_ids` on a note as "explicit recipients", not "FYI".
+3. **Recipient's `notification_type`** — `inbox` (default for internal
+   users) puts the notif on the in-app inbox only; `email` (default for
+   portal users and partners-without-a-user) creates a `mail.mail` and
+   sends. Set per `res.users`.
+
+## Key models
+
+- `mail.thread` — mixin; gives `message_post`, `message_subscribe`, `message_unsubscribe`
+- `mail.message` — one chatter entry. Fields: `body` (HTML), `subject`, `message_type`, `subtype_id`, `model`, `res_id`, `author_id`, `partner_ids`, `attachment_ids`, `parent_id`, `email_from`
+- `mail.message.subtype` — the `mt_note` / `mt_comment` / `mt_activities` distinction
+- `mail.followers` — who follows what. `partner_id` (always partner, never user) + `subtype_ids`
+- `mail.notification` — per-recipient delivery state (`sent` / `bounce` / `exception` / `read`) and `notification_type` (`inbox` / `email`)
+- `mail.activity` + `mail.activity.type` — to-dos with deadlines (separate from messages)
+- `mail.activity.mixin` — gives `activity_schedule`
+- `ir.attachment` — files
+- `mail.template` — QWeb-rendered email templates
+- `ir.mail_server` — outbound SMTP config (vanilla)
+- `mail.alias` — inbound email routing
+
+## Recipes
+
+### 1. Internal note (no email sent)
+
+```python
+# Default subtype is mt_note when subtype_xmlid is omitted
+env['res.partner'].browse(partner_id).message_post(
+    body="<p>Called customer. Wants a quote by Friday.</p>",
+)
+```
+
+### 2. Send a real message to followers (triggers email)
+
+```python
+env['sale.order'].browse(order_id).message_post(
+    body="<p>Quote v2 attached, please review.</p>",
+    subject="Quote update",
+    subtype_xmlid='mail.mt_comment',     # required to send email
+    message_type='comment',              # user-typed comment
+    partner_ids=[customer_partner_id],   # extra recipients on top of followers
+    attachment_ids=[attachment_id],
+)
+```
+
+### 3. Notify specific people without polluting the chatter of a record
+
+Use `message_notify` instead of `message_post` — pushes inbox/email
+notifications without rendering on the document.
+
+### 4. Attachments
+
+Two ways. **Over XML-RPC, only the first works** — see Gotchas.
+
+```python
+# A. Pre-create ir.attachment, then reference (works everywhere)
+att = env['ir.attachment'].create({
+    'name': 'quote_v2.pdf',
+    'datas': base64_content,            # base64-encoded bytes
+    'res_model': 'sale.order',
+    'res_id': order_id,
+})
+record.message_post(body="...", attachment_ids=[att.id])
+
+# B. Inline tuples — only works in-process / over JSON-RPC, NOT XML-RPC
+record.message_post(
+    body="...",
+    attachments=[('quote_v2.pdf', raw_bytes)],   # raw bytes, not base64
+)
+```
+
+### 5. Followers
+
+Followers are **partners**, not users. To follow as a user, pass that
+user's `partner_id`.
+
+```python
+record.message_subscribe(partner_ids=[partner_id])
+record.message_unsubscribe(partner_ids=[partner_id])
+```
+
+### 6. Schedule an activity
+
+```python
+env['crm.lead'].browse(lead_id).activity_schedule(
+    act_type_xmlid='mail.mail_activity_data_call',   # or _todo, _meeting, _email
+    date_deadline='2026-05-12',
+    summary='Follow-up call',
+    note='<p>Confirm budget.</p>',
+    user_id=responsible_user_id,
+)
+```
+
+Activity types are records of `mail.activity.type`; they have
+`category` (`default` / `upload_file` / `phonecall`) which drives UI
+behavior. `chaining_type` controls whether marking-done suggests or
+auto-creates the next activity.
+
+## Sending vs queueing — the cron
+
+`message_post` synchronously creates the `mail.message`,
+`mail.notification`, and `mail.mail` rows. By default, Odoo also
+attempts the actual SMTP send within the same request (`force_send=True`
+inside `_notify_thread_by_email`). What you observe right after the
+call:
+
+- `mail.notification.notification_status` → `sent` (success) or `exception` (failure)
+- `mail.mail.state` → `sent` (then auto-deleted, see below) or `exception`
+
+If a `mail.mail` ends up in `outgoing` (no synchronous send attempted,
+or got skipped), the **`Mail: Email Queue Manager`** cron picks it up.
+Default interval: **1 hour**, both v18 and v19 — not 60 seconds.
+`mail.mail` rows in `state='exception'` are **not** retried by the
+cron; you must `action_send()` them manually after fixing the cause.
+
+`mail.mail` records have `auto_delete=True` by default — they
+disappear from the table after a successful send. If you need to know
+"what was actually sent", read `mail.notification`, not `mail.mail`.
+
+To trigger the queue from the API:
+
+```python
+env.ref('mail.ir_cron_mail_scheduler_action').method_direct_trigger()
+# or, send specific mails synchronously:
+env['mail.mail'].browse([id1, id2]).send()
+```
+
+## Vanilla Odoo vs Odoo + pan_outlook_pro
+
+The chatter API surface (`message_post`, `activity_schedule`,
+attachments, followers) is unchanged. Differences are in transport,
+detection, and a few extra fields:
+
+| | Vanilla Odoo | + `pan_outlook_pro` |
+|---|---|---|
+| Outbound transport | SMTP via `ir.mail_server` | Microsoft Graph API per user/mailbox (with SMTP fallback, see below) |
+| `From` address | One server-wide sender, often `notifications@…` | Real mailbox of choice (personal / shared / notification) |
+| Inbound | `fetchmail.server` (IMAP/POP) or `mail.alias` MX | Cron `Microsoft Graph: Fetch Incoming Mail` every **1 min**; routes via `mail.alias` |
+| OAuth state | n/a | Fernet-encrypted tokens on `res.users` |
+| Extra `mail.message` fields | none | `x_microsoft_message_id`, `x_microsoft_conversation_id` (both indexed) |
+| `ir.mail_server` after install | unchanged | post-init hook deactivates all existing rows; module installs one placeholder `[Outlook Pro] SMTP Disabled` (active=True, host unresolvable) |
+
+### Three Outlook Pro install stages — different failure modes
+
+What an MCP user sees when posting `mt_comment` depends on which stage
+the install is in. Detect via `x_microsoft.mailbox` row count:
+
+| Stage | `x_microsoft.mailbox` (incl. archived) | Mailbox active for current user? | Outbound `mail.mail` ends up | What user observes |
+|---|---|---|---|---|
+| Installed only | 0 rows | n/a | `state=exception` via SMTP fallback | `failure_reason: "-2\nName or service not known"` (DNS error from placeholder server) |
+| Configured, not connected | ≥1 row | no | `state=cancel` | Silently dropped, no notification email, no error |
+| Fully configured | ≥1 row | yes | `state=sent` via Graph | `x_microsoft_message_id` populated on the message |
+
+The smart fallback is in `pan_outlook_pro/models/mail_mail.py:80-93`:
+no mailbox at all → standard SMTP path. This keeps demo / dev
+environments working but produces a confusing DNS-error if SMTP isn't
+configured. **If you see `"Name or service not known"` after a fresh
+Outlook Pro install, the cause is "no mailbox configured", not "SMTP
+broken".**
+
+### Detection
+
+Outlook Pro is installed iff:
+
+- `ir.module.module` row exists with `name='pan_outlook_pro'` and `state='installed'`, **or**
+- `ir.model.fields` has `(model='mail.message', name='x_microsoft_message_id')`, **or**
+- `ir.model` has a row with `model='x_microsoft.mailbox'`
+
+Stage detection — once installed, count
+`x_microsoft.mailbox` (with `active_test=False`) for "any mailbox
+ever configured", and search `[('active','=',True)]` on the model
+referenced by the mail's responsible user for "configured for sending".
+
+### Other Outlook Pro behavior an MCP user should know
+
+- Inbound emails arriving via Graph can land on any thread-enabled model (routed by `mail.alias`), not only the partner's chatter.
+- Sent Items in Outlook are pulled back in as `mail.message` for 2-way sync — don't double-post by also sending a `message_post` for emails the user already sent in Outlook.
+- Mass-mailing emails (`mailing.mailing`, e.g. Brevo campaigns) keep going via standard SMTP even when Outlook Pro is fully configured.
+
+## Gotchas
+
+- `partner_ids` everywhere = partners, not users. Convert via `res.users.partner_id`.
+- `partner_ids` on a *note* still creates `mail.notification` + `mail.mail` for those partners. The `mt_note` subtype only suppresses the *implicit* follower fan-out, not explicit recipients.
+- `body` is HTML. Plain strings are HTML-escaped; pass `markupsafe.Markup(...)` only if you control the source.
+- `body_is_html=True` is only for RPC calls where you're forcing string-typed HTML through.
+- Tracked-field changes auto-post a system message — don't `message_post` the same change twice.
+- `message_type='user_notification'` is reserved for `message_notify`; `message_post` rejects it.
+- `outgoing_email_to` (and `incoming_email_to` / `incoming_email_cc`) are **Odoo v19+ only**. On v18 they raise `ValueError: Those values are not supported when posting or notifying`. For pre-v19, add CC recipients as `partner_ids`.
+- **Inline `attachments=[(name, raw_bytes)]` does not work over XML-RPC** — Odoo's `_process_attachments_for_post` calls `base64.b64encode(content)` and crashes with `TypeError: a bytes-like object is required, not 'Binary'`. Pre-create `ir.attachment` and pass `attachment_ids=[id]` instead.
+- A note (`mt_note`) is hidden from portal/public users via `internal=True` on the subtype.
+- Followers without the right subtype subscription won't get notified, even if they follow the record. Subtype subscription = filter, not just on/off.
+- `email_from` lets you spoof the visible sender; Odoo will try to make `author_id` and `email_from` coherent. Pass both or neither.
+- Activities live on `mail.activity`, not `mail.message`. Closing an activity *posts* a `mt_activities`-subtype message — that's how chatter shows "X done".
+- v18 vs v19: same post can produce different notification counts. v18 tends to add the author's partner as an extra notified party; v19 doesn't with the same defaults. Don't trust an exact count — read `mail.notification` rows back if it matters.
+- On Outlook Pro, `mail.alias` is still the routing config for inbound — vanilla aliases keep working, just fed by Graph instead of MX.

--- a/tests/test_post_message.py
+++ b/tests/test_post_message.py
@@ -11,7 +11,6 @@ from mcp_server_odoo.access_control import AccessControlError
 from mcp_server_odoo.error_handling import ValidationError
 from mcp_server_odoo.tools import OdooToolHandler
 
-
 # ---------------------------------------------------------------------------
 # Unit tests with a mocked OdooConnection
 # ---------------------------------------------------------------------------
@@ -54,12 +53,12 @@ class TestPostMessageUnit:
         """Default subtype is mt_comment; only body is required in kwargs."""
         # existence check + message read + outlook field probe
         mock_connection.read.side_effect = [
-            [{"id": 7}],                                    # existence check
+            [{"id": 7}],  # existence check
             [{"subtype_id": [1, "Discussions"], "attachment_ids": []}],  # message readback
         ]
-        mock_connection.fields_get.return_value = {}        # no outlook field
-        mock_connection.call_method.return_value = 42        # message_post returns mail.message id
-        mock_connection.search_read.return_value = []       # no notifications
+        mock_connection.fields_get.return_value = {}  # no outlook field
+        mock_connection.call_method.return_value = 42  # message_post returns mail.message id
+        mock_connection.search_read.return_value = []  # no notifications
 
         result = await handler._handle_post_message_tool(
             model="res.partner", record_id=7, body="<p>hi</p>"
@@ -134,15 +133,15 @@ class TestPostMessageUnit:
         """When mail.message has x_microsoft_message_id, surface it."""
         mock_connection.read.side_effect = [
             [{"id": 7}],
-            [{
-                "subtype_id": [1, "Discussions"],
-                "attachment_ids": [],
-                "x_microsoft_message_id": "<AAMkAG...>",
-            }],
+            [
+                {
+                    "subtype_id": [1, "Discussions"],
+                    "attachment_ids": [],
+                    "x_microsoft_message_id": "<AAMkAG...>",
+                }
+            ],
         ]
-        mock_connection.fields_get.return_value = {
-            "x_microsoft_message_id": {"type": "char"}
-        }
+        mock_connection.fields_get.return_value = {"x_microsoft_message_id": {"type": "char"}}
         mock_connection.call_method.return_value = 42
         mock_connection.search_read.return_value = []
 
@@ -162,9 +161,7 @@ class TestPostMessageUnit:
     @pytest.mark.asyncio
     async def test_empty_body_rejected(self, handler):
         with pytest.raises(ValidationError, match="body is required"):
-            await handler._handle_post_message_tool(
-                model="res.partner", record_id=7, body=""
-            )
+            await handler._handle_post_message_tool(model="res.partner", record_id=7, body="")
 
     @pytest.mark.asyncio
     async def test_access_denied(self, handler, mock_access_controller):
@@ -201,7 +198,9 @@ class TestPostMessageUnit:
         ]
 
         result = await handler._handle_post_message_tool(
-            model="res.partner", record_id=7, body="<p>hi</p>",
+            model="res.partner",
+            record_id=7,
+            body="<p>hi</p>",
             partner_ids=[11, 12],
         )
         assert len(result["notifications"]) == 2
@@ -215,6 +214,7 @@ class TestPostMessageUnit:
 # ---------------------------------------------------------------------------
 # Integration tests against the local docker stack
 # ---------------------------------------------------------------------------
+
 
 # Read deploy/.env.test if available so the test can target odoo18 / odoo19
 # without needing the user to mess with environment variables.
@@ -248,6 +248,7 @@ def _make_handler_for(target: str):
     Returns (handler, base_url, db) or None if the env / server is unreachable.
     """
     import socket
+
     from mcp.server.fastmcp import FastMCP
 
     from mcp_server_odoo.access_control import AccessController
@@ -270,6 +271,7 @@ def _make_handler_for(target: str):
 
     # Quick TCP probe
     from urllib.parse import urlparse
+
     parsed = urlparse(url)
     host = parsed.hostname or "localhost"
     port = parsed.port or 8069

--- a/tests/test_post_message.py
+++ b/tests/test_post_message.py
@@ -1,0 +1,389 @@
+"""Tests for the post_message chatter tool."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import Mock
+
+import pytest
+
+from mcp_server_odoo.access_control import AccessControlError
+from mcp_server_odoo.error_handling import ValidationError
+from mcp_server_odoo.tools import OdooToolHandler
+
+
+# ---------------------------------------------------------------------------
+# Unit tests with a mocked OdooConnection
+# ---------------------------------------------------------------------------
+
+
+class TestPostMessageUnit:
+    """Mock-driven tests for post_message argument assembly + return shape."""
+
+    @pytest.fixture
+    def mock_app(self):
+        app = Mock()
+        app.tool = Mock(side_effect=lambda **kwargs: lambda func: func)
+        return app
+
+    @pytest.fixture
+    def mock_connection(self):
+        conn = Mock()
+        conn.is_authenticated = True
+        conn._base_url = "http://localhost:8169"
+        return conn
+
+    @pytest.fixture
+    def mock_access_controller(self):
+        controller = Mock()
+        controller.validate_model_access = Mock()
+        return controller
+
+    @pytest.fixture
+    def mock_config(self):
+        config = Mock()
+        config.url = "http://localhost:8169"
+        return config
+
+    @pytest.fixture
+    def handler(self, mock_app, mock_connection, mock_access_controller, mock_config):
+        return OdooToolHandler(mock_app, mock_connection, mock_access_controller, mock_config)
+
+    @pytest.mark.asyncio
+    async def test_message_post_kwargs_minimal(self, handler, mock_connection):
+        """Default subtype is mt_comment; only body is required in kwargs."""
+        # existence check + message read + outlook field probe
+        mock_connection.read.side_effect = [
+            [{"id": 7}],                                    # existence check
+            [{"subtype_id": [1, "Discussions"], "attachment_ids": []}],  # message readback
+        ]
+        mock_connection.fields_get.return_value = {}        # no outlook field
+        mock_connection.call_method.return_value = 42        # message_post returns mail.message id
+        mock_connection.search_read.return_value = []       # no notifications
+
+        result = await handler._handle_post_message_tool(
+            model="res.partner", record_id=7, body="<p>hi</p>"
+        )
+
+        assert result["success"] is True
+        assert result["message_id"] == 42
+        assert result["subtype"] == "Discussions"
+        assert result["outlook_pro_message_id"] is None
+        assert result["notifications"] == []
+
+        # call_method signature: (model, method, ids=[record_id], **kwargs)
+        positional = mock_connection.call_method.call_args.args
+        kw = mock_connection.call_method.call_args.kwargs
+        assert positional == ("res.partner", "message_post")
+        assert kw["ids"] == [7]
+        assert kw["body"] == "<p>hi</p>"
+        assert kw["subtype_xmlid"] == "mail.mt_comment"
+        assert kw["message_type"] == "comment"
+        assert "subject" not in kw
+        assert "partner_ids" not in kw
+        assert "outgoing_email_to" not in kw
+
+    @pytest.mark.asyncio
+    async def test_message_post_kwargs_full(self, handler, mock_connection):
+        """All optional kwargs forwarded; cc maps to outgoing_email_to."""
+        mock_connection.read.side_effect = [
+            [{"id": 7}],
+            [{"subtype_id": [2, "Note"], "attachment_ids": [9, 10]}],
+        ]
+        mock_connection.fields_get.return_value = {}
+        mock_connection.call_method.return_value = 99
+        mock_connection.search_read.return_value = []
+
+        await handler._handle_post_message_tool(
+            model="crm.lead",
+            record_id=7,
+            body="<p>x</p>",
+            subject="Subject",
+            partner_ids=[1, 2],
+            attachment_ids=[9, 10],
+            subtype_xmlid="mail.mt_note",
+            cc="extra@example.com",
+        )
+
+        kw = mock_connection.call_method.call_args.kwargs
+        assert kw["ids"] == [7]
+        assert kw["subject"] == "Subject"
+        assert kw["partner_ids"] == [1, 2]
+        assert kw["attachment_ids"] == [9, 10]
+        assert kw["subtype_xmlid"] == "mail.mt_note"
+        assert kw["outgoing_email_to"] == "extra@example.com"
+
+    @pytest.mark.asyncio
+    async def test_message_post_returns_list_normalised(self, handler, mock_connection):
+        """Some transports wrap singleton id in a list — we unwrap."""
+        mock_connection.read.side_effect = [
+            [{"id": 7}],
+            [{"subtype_id": [1, "Discussions"], "attachment_ids": []}],
+        ]
+        mock_connection.fields_get.return_value = {}
+        mock_connection.call_method.return_value = [55]
+        mock_connection.search_read.return_value = []
+
+        result = await handler._handle_post_message_tool(
+            model="res.partner", record_id=7, body="<p>hi</p>"
+        )
+        assert result["message_id"] == 55
+
+    @pytest.mark.asyncio
+    async def test_outlook_pro_message_id_surfaced(self, handler, mock_connection):
+        """When mail.message has x_microsoft_message_id, surface it."""
+        mock_connection.read.side_effect = [
+            [{"id": 7}],
+            [{
+                "subtype_id": [1, "Discussions"],
+                "attachment_ids": [],
+                "x_microsoft_message_id": "<AAMkAG...>",
+            }],
+        ]
+        mock_connection.fields_get.return_value = {
+            "x_microsoft_message_id": {"type": "char"}
+        }
+        mock_connection.call_method.return_value = 42
+        mock_connection.search_read.return_value = []
+
+        result = await handler._handle_post_message_tool(
+            model="res.partner", record_id=7, body="<p>hi</p>"
+        )
+        assert result["outlook_pro_message_id"] == "<AAMkAG...>"
+
+    @pytest.mark.asyncio
+    async def test_record_not_found(self, handler, mock_connection):
+        mock_connection.read.return_value = []
+        with pytest.raises(ValidationError, match="Record not found"):
+            await handler._handle_post_message_tool(
+                model="res.partner", record_id=999, body="<p>x</p>"
+            )
+
+    @pytest.mark.asyncio
+    async def test_empty_body_rejected(self, handler):
+        with pytest.raises(ValidationError, match="body is required"):
+            await handler._handle_post_message_tool(
+                model="res.partner", record_id=7, body=""
+            )
+
+    @pytest.mark.asyncio
+    async def test_access_denied(self, handler, mock_access_controller):
+        mock_access_controller.validate_model_access.side_effect = AccessControlError(
+            "Access denied to res.partner.write"
+        )
+        with pytest.raises(ValidationError, match="Access denied"):
+            await handler._handle_post_message_tool(
+                model="res.partner", record_id=7, body="<p>x</p>"
+            )
+
+    @pytest.mark.asyncio
+    async def test_notifications_formatted(self, handler, mock_connection):
+        """Each mail.notification row is reduced to a flat per-recipient dict."""
+        mock_connection.read.side_effect = [
+            [{"id": 7}],
+            [{"subtype_id": [1, "Discussions"], "attachment_ids": []}],
+        ]
+        mock_connection.fields_get.return_value = {}
+        mock_connection.call_method.return_value = 42
+        mock_connection.search_read.return_value = [
+            {
+                "res_partner_id": [11, "Alice"],
+                "notification_type": "email",
+                "notification_status": "sent",
+                "failure_reason": False,
+            },
+            {
+                "res_partner_id": [12, "Bob"],
+                "notification_type": "inbox",
+                "notification_status": "ready",
+                "failure_reason": False,
+            },
+        ]
+
+        result = await handler._handle_post_message_tool(
+            model="res.partner", record_id=7, body="<p>hi</p>",
+            partner_ids=[11, 12],
+        )
+        assert len(result["notifications"]) == 2
+        assert result["notifications"][0]["partner_name"] == "Alice"
+        assert result["notifications"][0]["type"] == "email"
+        assert result["notifications"][0]["status"] == "sent"
+        assert result["notifications"][1]["partner_name"] == "Bob"
+        assert result["notifications"][1]["type"] == "inbox"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests against the local docker stack
+# ---------------------------------------------------------------------------
+
+# Read deploy/.env.test if available so the test can target odoo18 / odoo19
+# without needing the user to mess with environment variables.
+def _load_local_test_env() -> dict:
+    """Best-effort load of admin-repo's deploy/.env.test for local testing."""
+    candidates = [
+        os.path.join(
+            os.path.dirname(__file__), "..", "..", "odoo-mcp-pro-admin", "deploy", ".env.test"
+        ),
+    ]
+    for path in candidates:
+        if os.path.exists(path):
+            out = {}
+            with open(path) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    k, v = line.split("=", 1)
+                    out[k] = v
+            return out
+    return {}
+
+
+LOCAL_ENV = _load_local_test_env()
+
+
+def _make_handler_for(target: str):
+    """Build a tool handler against odoo18 (vanilla) or odoo19 (outlook pro).
+
+    Returns (handler, base_url, db) or None if the env / server is unreachable.
+    """
+    import socket
+    from mcp.server.fastmcp import FastMCP
+
+    from mcp_server_odoo.access_control import AccessController
+    from mcp_server_odoo.config import OdooConfig
+    from mcp_server_odoo.odoo_connection import OdooConnection
+
+    if target == "odoo18":
+        url = LOCAL_ENV.get("ODOO18_URL")
+        db = LOCAL_ENV.get("ODOO18_DB")
+        key = LOCAL_ENV.get("ODOO18_API_KEY")
+    elif target == "odoo19":
+        url = LOCAL_ENV.get("ODOO19_URL")
+        db = LOCAL_ENV.get("ODOO19_DB")
+        key = LOCAL_ENV.get("ODOO19_API_KEY")
+    else:
+        return None
+
+    if not url or not key or not db:
+        return None
+
+    # Quick TCP probe
+    from urllib.parse import urlparse
+    parsed = urlparse(url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 8069
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(1)
+    if sock.connect_ex((host, port)) != 0:
+        sock.close()
+        return None
+    sock.close()
+
+    config = OdooConfig(url=url, database=db, api_key=key, username="admin", api_version="xmlrpc")
+    conn = OdooConnection(config)
+    conn.connect()
+    conn.authenticate()
+    app = FastMCP("test")
+    handler = OdooToolHandler(app, conn, AccessController(config), config)
+    return handler, url, db
+
+
+def _ensure_test_partner(conn, name: str, email: str) -> int:
+    ids = conn.search("res.partner", [("name", "=", name)], limit=1)
+    if ids:
+        return ids[0]
+    return conn.create("res.partner", {"name": name, "email": email})
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_integration_note_silent_on_odoo18():
+    """A pure note (mt_note, no recipients) creates 0 notifications, 0 mail.mail."""
+    bundle = _make_handler_for("odoo18")
+    if bundle is None:
+        pytest.skip("odoo18 not reachable or .env.test missing")
+    handler, _, _ = bundle
+    partner_id = _ensure_test_partner(handler.connection, "post_message_test", "test@example.com")
+
+    result = await handler._handle_post_message_tool(
+        model="res.partner",
+        record_id=partner_id,
+        body="<p>integration note</p>",
+        subtype_xmlid="mail.mt_note",
+    )
+    assert result["success"] is True
+    assert result["subtype"] == "Note"
+    assert result["notifications"] == []
+    assert result["outlook_pro_message_id"] is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_integration_message_with_partner_on_odoo18():
+    """Message with explicit recipient creates a notification."""
+    bundle = _make_handler_for("odoo18")
+    if bundle is None:
+        pytest.skip("odoo18 not reachable or .env.test missing")
+    handler, _, _ = bundle
+    partner_id = _ensure_test_partner(handler.connection, "post_message_test", "test@example.com")
+    rcpt_id = _ensure_test_partner(handler.connection, "post_message_rcpt", "rcpt@example.com")
+
+    result = await handler._handle_post_message_tool(
+        model="res.partner",
+        record_id=partner_id,
+        body="<p>integration message</p>",
+        partner_ids=[rcpt_id],
+    )
+    assert result["success"] is True
+    assert result["subtype"] == "Discussions"
+    assert any(n["partner_id"] == rcpt_id for n in result["notifications"])
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_integration_outlook_pro_field_present_on_odoo19():
+    """On odoo19+pan_outlook_pro, x_microsoft_message_id field is read (may be None without OAuth)."""
+    bundle = _make_handler_for("odoo19")
+    if bundle is None:
+        pytest.skip("odoo19 not reachable or .env.test missing")
+    handler, _, _ = bundle
+
+    # Confirm pan_outlook_pro is installed; skip if not
+    installed = handler.connection.search(
+        "ir.module.module",
+        [("name", "=", "pan_outlook_pro"), ("state", "=", "installed")],
+        limit=1,
+    )
+    if not installed:
+        pytest.skip("pan_outlook_pro not installed on odoo19")
+
+    partner_id = _ensure_test_partner(handler.connection, "post_message_test", "test@example.com")
+    result = await handler._handle_post_message_tool(
+        model="res.partner",
+        record_id=partner_id,
+        body="<p>outlook pro probe</p>",
+        subtype_xmlid="mail.mt_note",  # silent — we only need the field probe
+    )
+    assert result["success"] is True
+    # outlook_pro_message_id key is present (None acceptable for a note)
+    assert "outlook_pro_message_id" in result
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_integration_cc_rejected_on_v18():
+    """outgoing_email_to is v19+; v18 must surface a clear error."""
+    bundle = _make_handler_for("odoo18")
+    if bundle is None:
+        pytest.skip("odoo18 not reachable or .env.test missing")
+    handler, _, _ = bundle
+    partner_id = _ensure_test_partner(handler.connection, "post_message_test", "test@example.com")
+
+    with pytest.raises(ValidationError):
+        await handler._handle_post_message_tool(
+            model="res.partner",
+            record_id=partner_id,
+            body="<p>x</p>",
+            cc="extra@example.com",
+        )


### PR DESCRIPTION
## Summary

- New `post_message` tool: post chatter messages or notes via the API. Synchronous send (no email-queue cron wait); equivalent to clicking "Send Message" / "Log Note" in the Odoo UI. Returns the `mail.message` id, per-recipient `mail.notification` rows, and on Odoo + `pan_outlook_pro` the Microsoft Graph `internetMessageId`.
- Companion `communications` skill: chatter API guide (note vs message, attachments, followers, activities) including vanilla-vs-`pan_outlook_pro` behavioral differences and the three Outlook Pro install stages with their distinct send-failure modes.
- Transport-agnostic `call_method` added to `OdooConnectionProtocol` and both backends (XML-RPC `execute_kw`, JSON/2 `_call`). Future tools wrapping recordset methods reuse this — no per-transport branching.

## Why

CRUD tools (`create_record` / `update_record`) can't trigger Odoo workflow methods. `message_post` is the canonical "send a chatter message" entry point and was previously unreachable from Claude. With Outlook Pro, the synchronous `mail.mail.send()` path means `message_post` is fast and routes via Microsoft Graph — better UX than enqueuing and waiting on the 1-hour cron.

## Test plan

- [x] 8 unit tests (mocked connection): kwarg assembly, list-vs-int return normalisation, `x_microsoft_message_id` surfacing, body/access validation, notification mapping
- [x] 4 integration tests against local docker stack: silent note on odoo18, message+partner on odoo18, Outlook-Pro field probe on odoo19, v18 `cc` rejection
- [x] E2E via MCP stdio against odoo18 (XML-RPC) and odoo19 (JSON/2) — both transports verified end-to-end
- [x] No regressions in 112 adjacent tests (8 pre-existing infrastructure errors unchanged)

## Notes

- Default `subtype_xmlid='mail.mt_comment'` — sends mail. `destructiveHint=True`.
- `cc` (`outgoing_email_to`) is Odoo v19+ only. v18 raises a clear `ValueError`.
- Inline `attachments=[(name, bytes)]` not supported over XML-RPC due to `xmlrpc.client.Binary` deserialization; tool only accepts `attachment_ids` (pre-create `ir.attachment`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)