### PR TITLE
fix(transport): switch streamable-http to stateless mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 - **Le Chat (Mistral) connector support**: per-AI Zitadel app routing so Le Chat can sign in via OAuth. Le Chat is a confidential client, so `/register` returns `client_secret` for it.
 
 ### Fixed
+- **Connection survives server deploys**: streamable-HTTP transport now runs in stateless mode (`stateless_http=True`, `json_response=True`). Previously the server kept session state in-memory per replica, so blue/green deploys dropped `Mcp-Session-Id` mappings and Claude/ChatGPT clients reported "connection lost". Stateless requests are independent, so any replica can serve any request and rolling deploys are invisible to clients. No server-initiated notifications were in use, so no feature loss.
 - **XML-RPC username resolution**: `registry.get_connection` now reads `user_conn.odoo_login` (when set) and falls back to `user_conn.email`. Odoo authenticates against `res.users.login`, which can differ from the user's email (e.g. `login="admin"`); the previous behavior locked everyone to the sign-up email.
 - **`server_info` observability**: `_current_sub` is now set before the registry/rate-limit calls in `_get_user_context`, so when those raise and a tool catches the exception (notably `server_info`), usage tracking still attributes the event to the correct user instead of silently no-op'ing as `"stdio"`.
 

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -246,12 +246,17 @@ class OdooMCPServer:
         # Configure OAuth if environment variables are set
         auth_settings, token_verifier = self._build_oauth_settings()
 
-        # Create FastMCP instance with server metadata
+        # Create FastMCP instance with server metadata.
+        # stateless_http=True so any replica can serve any request — sessions
+        # don't pin to a single container, so blue/green deploys don't drop
+        # client connections with "No transport found for sessionId".
         self.app = FastMCP(
             name="odoo-mcp-server",
             instructions=SERVER_INSTRUCTIONS,
             auth=auth_settings,
             token_verifier=token_verifier,
+            stateless_http=True,
+            json_response=True,
         )
 
         if auth_settings:

--- a/tests/test_server_foundation.py
+++ b/tests/test_server_foundation.py
@@ -63,6 +63,23 @@ class TestServerFoundation:
         assert server.app is not None
         assert server.app.name == "odoo-mcp-server"
 
+    def test_streamable_http_is_stateless(self, valid_config):
+        """Streamable-http must run stateless so blue/green deploys don't drop
+        client connections with 'No transport found for sessionId'. Pair with
+        json_response=True since we use no server-initiated notifications.
+        Reverting either flag is the regression we are guarding against.
+        """
+        server = OdooMCPServer(valid_config)
+
+        assert server.app.settings.stateless_http is True, (
+            "FastMCP must be stateless_http=True; otherwise sessions pin to a "
+            "single replica and deploys disconnect every client."
+        )
+        assert server.app.settings.json_response is True, (
+            "FastMCP must be json_response=True; SSE GET streams are pointless "
+            "in stateless mode and break json-only HTTP clients."
+        )
+
     def test_server_initialization_with_env_config(self, monkeypatch, tmp_path):
         """Test server initialization loading config from environment."""
         # Reset config singleton first

--- a/tests/test_transport_integration.py
+++ b/tests/test_transport_integration.py
@@ -121,14 +121,19 @@ class HttpTransportTester:
             if "mcp-session-id" in response.headers:
                 self.session_id = response.headers["mcp-session-id"]
 
-            # Parse SSE response
+            # Parse response — either plain JSON (json_response=True) or SSE.
             if response.status_code == 200:
-                events = self._parse_sse_response(response.text)
-                for event in events:
-                    if request_id is not None and event.get("id") == request_id:
+                if request_id is None:
+                    return {"status": response.status_code}
+                content_type = response.headers.get("content-type", "")
+                if content_type.startswith("application/json"):
+                    event = response.json()
+                    if event.get("id") == request_id:
                         return event
-                    elif request_id is None:
-                        return {"status": response.status_code}
+                else:
+                    for event in self._parse_sse_response(response.text):
+                        if event.get("id") == request_id:
+                            return event
 
             return {
                 "error": f"Request failed with status {response.status_code}",
@@ -217,7 +222,10 @@ class TestTransportIntegration:
             assert response is not None, "No response to initialize request"
             assert "error" not in response, f"Error in initialize response: {response}"
             assert "result" in response, f"Expected result in response, got: {response}"
-            assert tester.session_id is not None, "No session ID received"
+            assert tester.session_id is None, (
+                "Server is configured stateless_http=True, so it must not "
+                "return an Mcp-Session-Id header on initialize."
+            )
 
             # Send initialized notification
             await tester._send_request("notifications/initialized", {})
@@ -232,37 +240,36 @@ class TestTransportIntegration:
             tester.stop_server()
 
     @pytest.mark.asyncio
-    async def test_http_transport_session_persistence(self, odoo_server_required):
-        """Test that HTTP transport maintains session across requests."""
+    async def test_http_transport_stateless_across_requests(self, odoo_server_required):
+        """Stateless transport: each request is independent, no session id needed.
+
+        Sending a stale Mcp-Session-Id (e.g. left over in a client cache from a
+        pre-stateless deploy) must not yield "No transport found for sessionId";
+        the server should ignore the header and serve the request.
+        """
         tester = HttpTransportTester()
 
         try:
-            # Start and initialize server
             assert await tester.start_server(), "Failed to start HTTP server"
 
-            # Initialize
-            init_params = {
-                "protocolVersion": "2025-03-26",
-                "capabilities": {},
-                "clientInfo": {"name": "pytest-http", "version": "1.0"},
-            }
-            response = await tester._send_request("initialize", init_params, tester._next_id())
-            assert response and "result" in response
-
-            original_session_id = tester.session_id
-            assert original_session_id is not None, "No session ID after initialize"
-
-            # Send initialized notification
-            await tester._send_request("notifications/initialized", {})
-
-            # Make multiple requests and verify session ID persists
+            # Skip initialize: in stateless mode it isn't required between requests.
+            # Make multiple tools/list calls without ever holding a session id.
             for i in range(3):
                 response = await tester._send_request("tools/list", {}, tester._next_id())
                 assert response is not None, f"No response to request {i + 1}"
                 assert "error" not in response, f"Error in request {i + 1}: {response}"
-                assert tester.session_id == original_session_id, (
-                    f"Session ID changed on request {i + 1}"
+                assert tester.session_id is None, (
+                    f"Server returned an Mcp-Session-Id on request {i + 1} — "
+                    "stateless_http=True is not in effect."
                 )
+
+            # Stale session id from an old deploy must be silently accepted.
+            tester.session_id = "stale-id-from-pre-stateless-deploy"
+            response = await tester._send_request("tools/list", {}, tester._next_id())
+            assert response is not None
+            assert "error" not in response, (
+                f"Server rejected a stale Mcp-Session-Id instead of ignoring it: {response}"
+            )
 
         finally:
             tester.stop_server()


### PR DESCRIPTION
## Summary
- Switches FastMCP to `stateless_http=True, json_response=True`
- Fixes connections being dropped on every blue/green deploy ([helpdesk #33](https://pantalytics.odoo.com/odoo/helpdesk/1/tickets/33))
- No feature loss — we have no server-initiated notifications (progress, sampling, elicitation) in our tools

## Why
Default streamable-http keeps session state in-memory per replica. When the old container is removed during a deploy, all `Mcp-Session-Id` mappings vanish; the new container responds with "No transport found for sessionId" and Claude/ChatGPT clients show "connection lost". Stateless mode makes every request independent so any replica can serve any request — same pattern Stripe and other production MCP servers use.

## Test plan
Verified against local-test stack with patched `server.py` hot-copied into `mcp-server-test`:

- [x] `initialize` returns `content-type: application/json` and **no** `Mcp-Session-Id` response header
- [x] `tools/list` succeeds with no session id (16 tools)
- [x] `docker restart mcp-server-test`; immediately `tools/list` succeeds with no reconnect
- [x] `tools/list` with a stale legacy `Mcp-Session-Id` header is silently accepted (no 404)
- [ ] Production: deploy this, then deploy again 5 min later, confirm own Claude session stays connected
- [ ] Production: respond to ticket #33 once verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)