### PR TITLE
docs(communications): warn against CDATA wrappers in message body

### DIFF
--- a/skills/communications/SKILL.md
+++ b/skills/communications/SKILL.md
@@ -334,6 +334,7 @@ referenced by the mail's responsible user for "configured for sending".
 - `partner_ids` on a *note* still creates `mail.notification` + `mail.mail` for those partners. The `mt_note` subtype only suppresses the *implicit* follower fan-out, not explicit recipients.
 - `body` is HTML. Plain strings are HTML-escaped; pass `markupsafe.Markup(...)` only if you control the source.
 - `body_is_html=True` is only for RPC calls where you're forcing string-typed HTML through.
+- **Never wrap `body` in `<![CDATA[ ... ]]>`.** CDATA is an XML escaping construct with no meaning in this code path — Odoo stores the markers verbatim and they show up in the rendered chatter and the outgoing email. Pass raw HTML directly; the JSON transport already handles `<`/`>`/`&` inside Python strings.
 - Tracked-field changes auto-post a system message — don't `message_post` the same change twice.
 - `message_type='user_notification'` is reserved for `message_notify`; `message_post` rejects it.
 - `outgoing_email_to` (and `incoming_email_to` / `incoming_email_cc`) are **Odoo v19+ only**. On v18 they raise `ValueError: Those values are not supported when posting or notifying`. For pre-v19, add CC recipients as `partner_ids`. On v19+, `cc` produces `mail.notification` rows with `res_partner_id=NULL` — Odoo handles that fine, but strict client-side result models (like `mcp_server_odoo`'s `PostMessageResult.notifications[].partner_id: int`) will fail to deserialize. Prefer `partner_ids` when the recipient has a `res.partner`.


### PR DESCRIPTION
## Summary

\`post_message\`'s \`body\` field is raw HTML — Odoo doesn't strip \`<![CDATA[ ... ]]>\` markers. They leak verbatim into the rendered chatter entry and the outgoing email.

Hit this today while sending a real customer reply (had to send a correction follow-up). Documenting in Gotchas so the next agent reaching for "to be safe with HTML special chars" doesn't repeat it.

One-line addition to the existing Gotchas list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)