### PR TITLE
fix(server_info): expose odoo_url for XML-RPC + add database field

### DIFF
--- a/mcp_server_odoo/odoo_connection.py
+++ b/mcp_server_odoo/odoo_connection.py
@@ -49,6 +49,10 @@ class OdooConnection:
         self.config = config
         self.timeout = timeout
         self._url_components = self._parse_url(config.url)
+        # Mirror OdooJSON2Connection._base_url so server_info() and any other
+        # caller that wants to know "which Odoo am I connected to" doesn't
+        # have to special-case the two connection types.
+        self._base_url = (config.url or "").rstrip("/")
 
         # Get appropriate endpoints based on mode
         endpoints = config.get_endpoint_paths()

--- a/mcp_server_odoo/schemas.py
+++ b/mcp_server_odoo/schemas.py
@@ -264,6 +264,10 @@ class ServerInfoResult(BaseModel):
     git_commit: str = Field(description="Git commit hash of the running build")
     api_version: str = Field(description="Odoo API version (json2 or xmlrpc)")
     odoo_url: str = Field(description="Connected Odoo instance URL")
+    database: Optional[str] = Field(
+        default=None,
+        description="Active Odoo database name. None on JSON/2 single-tenant where the API key resolves it server-side.",
+    )
     connected: bool = Field(description="Whether the server is connected to Odoo")
     runtime_id: str = Field(description="Server runtime identifier")
     companies: List[Dict[str, Any]] = Field(

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -38,7 +38,7 @@ from .version_detect import detect_api_version
 logger = get_logger(__name__)
 
 # Server version — keep in sync with pyproject.toml
-SERVER_VERSION = "1.5.0"
+SERVER_VERSION = "1.5.1"
 GIT_COMMIT = os.environ.get("GIT_COMMIT", "unknown")
 _BUILD_ORIGIN = "pnl-mcp-7f3a"  # Pantalytics provenance tag
 

--- a/mcp_server_odoo/tools.py
+++ b/mcp_server_odoo/tools.py
@@ -636,14 +636,18 @@ class OdooToolHandler:
                     else False
                 )
                 api_version = self.config.api_version if self.config else "json2"
-                # Use the connection's actual URL (tenant URL), not the global config
+                # Use the connection's actual URL (tenant URL), not the global config.
+                # Both XML-RPC and JSON/2 connections expose _base_url; the getattr
+                # fallback is just defensive in case of a stale connection object.
                 odoo_url = getattr(connection, "_base_url", None) or (
                     self.config.url if self.config else "multi-tenant"
                 )
+                database = getattr(connection, "database", None)
             except Exception:
                 is_connected = False
                 api_version = self.config.api_version if self.config else "unknown"
                 odoo_url = "not connected"
+                database = None
 
             # Fetch companies for context (helps with multi-company setups)
             companies = []
@@ -661,6 +665,7 @@ class OdooToolHandler:
                 git_commit=GIT_COMMIT,
                 api_version=api_version,
                 odoo_url=odoo_url,
+                database=database,
                 connected=is_connected,
                 runtime_id=_BUILD_ORIGIN,
                 companies=companies,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-server-odoo"
-version = "1.5.0"
+version = "1.5.1"
 description = "AI connector for Odoo ERP -- connect Claude, ChatGPT, and other AI tools to Odoo via MCP (Model Context Protocol)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_odoo_connection_basic.py
+++ b/tests/test_odoo_connection_basic.py
@@ -67,6 +67,27 @@ class TestOdooConnectionInit:
         conn = OdooConnection(test_config, timeout=60)
         assert conn.timeout == 60
 
+    def test_init_exposes_base_url(self, test_config):
+        """OdooConnection mirrors OdooJSON2Connection._base_url so server_info
+        and other callers can read the connected URL uniformly across both
+        connection types."""
+        conn = OdooConnection(test_config)
+        assert conn._base_url == test_config.url.rstrip("/")
+
+    def test_init_base_url_strips_trailing_slash(self):
+        """Trailing slashes are normalised so concatenation against a path
+        (like '/web/database/list') doesn't produce a double slash."""
+        config = OdooConfig(
+            url="https://example.odoo.com/",
+            api_key="test-key",
+            username="admin",
+            database="testdb",
+            api_version="xmlrpc",
+            skip_validation=True,
+        )
+        conn = OdooConnection(config)
+        assert conn._base_url == "https://example.odoo.com"
+
     def test_parse_url_https(self):
         """Test URL parsing for HTTPS URLs."""
         config = OdooConfig(


### PR DESCRIPTION
## Summary

\`server_info\` had two gaps that an agent hits the moment it asks \"which Odoo am I connected to?\":

1. **\`odoo_url\` was empty for XML-RPC connections.** \`OdooConnection\` stored its URL inside \`self._url_components\` but \`OdooJSON2Connection\` (v19+) exposed \`self._base_url\`. The tool's \`getattr(connection, \"_base_url\", None)\` therefore returned \`None\` for XML-RPC and the fallback (\`self.config.url\`) is the global dummy in multi-tenant mode → user saw \`odoo_url: \"\"\`.

2. **No \`database\` field on \`ServerInfoResult\`.** Both connection classes already expose \`.database\` as a property — the schema just didn't surface it.

## Changes

- \`OdooConnection.__init__\` now mirrors \`OdooJSON2Connection\` by setting \`self._base_url = config.url.rstrip(\"/\")\`. Trailing slash stripped so concatenation against paths doesn't double-slash.
- \`ServerInfoResult\` gains \`database: Optional[str]\` with a description that explains the JSON/2 single-tenant case where the API key resolves the db server-side.
- \`server_info\` tool reads \`connection.database\` and populates the new field.
- Two unit tests on \`TestOdooConnectionInit\` covering both the new attribute and trailing-slash normalisation.

## Test plan

- [x] \`pytest tests/test_odoo_connection_basic.py\` — 25 passed (incl. 2 new)
- [ ] After merge: bump admin-repo dependency + redeploy → re-run server_info from Claude, verify \`odoo_url\` and \`database\` are now populated for an XML-RPC connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)