### PR TITLE
fix(verify): bypass Cloudflare via curl_cffi + shotgun detection with evidence matrix

### DIFF
--- a/mcp_server_odoo/detection.py
+++ b/mcp_server_odoo/detection.py
@@ -481,9 +481,7 @@ def _aggregate(probes: List[ProbeResult]) -> DetectionResult:
     if json2_alive:
         api_version: ApiVersion = "json2"
         if major is not None and major < JSON2_MIN_VERSION:
-            conflicts.append(
-                f"json2_endpoint_live_but_version_probe_says_v{major}"
-            )
+            conflicts.append(f"json2_endpoint_live_but_version_probe_says_v{major}")
             # Trust json2: the version probe is likely cached or wrong.
             major = max(major, JSON2_MIN_VERSION)
     elif major is not None:
@@ -524,7 +522,9 @@ def _aggregate(probes: List[ProbeResult]) -> DetectionResult:
     contributing = sum(
         1
         for p in probes
-        if p.ok and p.name in {
+        if p.ok
+        and p.name
+        in {
             "xmlrpc_version",
             "web_version",
             "jsonrpc_version",
@@ -570,8 +570,7 @@ async def detect_odoo(url: str, timeout: int = PROBE_TIMEOUT_SECONDS) -> Detecti
         probes: List[ProbeResult] = list(await asyncio.gather(*tasks))
     result = _aggregate(probes)
     logger.info(
-        "Detected %s: api=%s major=%s hosting=%s waf=%s confidence=%s "
-        "(probes_ok=%d/%d)",
+        "Detected %s: api=%s major=%s hosting=%s waf=%s confidence=%s (probes_ok=%d/%d)",
         url,
         result.api_version,
         result.major,

--- a/mcp_server_odoo/detection.py
+++ b/mcp_server_odoo/detection.py
@@ -42,7 +42,6 @@ from typing import Any, Dict, List, Literal, Optional, Tuple
 from urllib.parse import urlparse
 
 from curl_cffi import requests as cffi_requests
-from curl_cffi.requests.errors import RequestsError
 
 logger = logging.getLogger(__name__)
 

--- a/mcp_server_odoo/detection.py
+++ b/mcp_server_odoo/detection.py
@@ -1,0 +1,604 @@
+"""Odoo server detection — shotgun probes + evidence aggregation.
+
+Instead of a sequential P1 → P2 → user-prompt detection ladder (one probe,
+fall back to the next on failure), this module fires *every* probe we know
+about in parallel and aggregates the evidence. Trade-off:
+
+- Slower than P1-happy-path (worst case ~max(probe latencies)) but no worse
+  than the old fallback when P1 failed.
+- One probe being blocked / lying no longer ruins the answer — the others
+  still come back with data and the aggregator votes.
+- The full evidence is persistable (see admin's `detection_evidence` JSONB
+  column) so production weirdness can be diagnosed without rerunning.
+
+Probes implemented:
+
+  1. xmlrpc_version       — stdlib XML-RPC version() on /xmlrpc/2/common
+  2. web_version          — GET /web/version (curl_cffi, Chrome TLS)
+  3. web_health           — GET /web/health (Odoo 17+ liveness)
+  4. web_login            — GET /web/login (HTML markers, db_monodb cookie)
+  5. root_headers         — GET / (server: nginx / Odoo.sh / cloudflare)
+  6. jsonrpc_version      — POST /jsonrpc with common.version
+  7. json2_unauth         — POST /json/2/res.users/context_get unauthenticated
+                            (401 "Invalid apikey" → JSON/2 endpoint live → v19+)
+  8. dns_cloudflare       — DNS A lookup + Cloudflare IP-range check
+
+The aggregator turns this into a DetectionResult with api_version,
+server_version, hosting, edition, behind_waf, and a confidence label.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import logging
+import re
+import socket
+import xmlrpc.client
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from time import perf_counter
+from typing import Any, Dict, List, Literal, Optional, Tuple
+from urllib.parse import urlparse
+
+from curl_cffi import requests as cffi_requests
+from curl_cffi.requests.errors import RequestsError
+
+logger = logging.getLogger(__name__)
+
+JSON2_MIN_VERSION = 19
+PROBE_TIMEOUT_SECONDS = 5
+_MAJOR_VERSION_RE = re.compile(r"(\d+)")
+_IMPERSONATE = "chrome"
+
+# Cloudflare's published IPv4 ranges (well-known, stable; refresh occasionally
+# from https://www.cloudflare.com/ips-v4 if you want to keep this current).
+_CLOUDFLARE_V4 = [
+    "173.245.48.0/20",
+    "103.21.244.0/22",
+    "103.22.200.0/22",
+    "103.31.4.0/22",
+    "141.101.64.0/18",
+    "108.162.192.0/18",
+    "190.93.240.0/20",
+    "188.114.96.0/20",
+    "197.234.240.0/22",
+    "198.41.128.0/17",
+    "162.158.0.0/15",
+    "104.16.0.0/13",
+    "104.24.0.0/14",
+    "172.64.0.0/13",
+    "131.0.72.0/22",
+]
+_CLOUDFLARE_NETS = [ipaddress.ip_network(c) for c in _CLOUDFLARE_V4]
+
+
+ApiVersion = Literal["json2", "xmlrpc", "unknown"]
+Hosting = Literal["online", "sh", "self_hosted", "behind_waf", "unknown"]
+Edition = Literal["community", "enterprise"]
+Confidence = Literal["high", "medium", "low"]
+
+
+@dataclass
+class ProbeResult:
+    name: str
+    ok: bool
+    latency_ms: int
+    status_code: Optional[int] = None
+    summary: Dict[str, Any] = field(default_factory=dict)
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = {
+            "name": self.name,
+            "ok": self.ok,
+            "latency_ms": self.latency_ms,
+            "summary": self.summary,
+        }
+        if self.status_code is not None:
+            d["status_code"] = self.status_code
+        if self.error is not None:
+            d["error"] = self.error
+        return d
+
+
+@dataclass
+class DetectionResult:
+    is_odoo: bool
+    api_version: ApiVersion
+    server_version: Optional[str]
+    major: Optional[int]
+    hosting: Hosting
+    edition: Optional[Edition]
+    behind_waf: bool
+    confidence: Confidence
+    probes: List[ProbeResult]
+    conflicts: List[str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "is_odoo": self.is_odoo,
+            "api_version": self.api_version,
+            "server_version": self.server_version,
+            "major": self.major,
+            "hosting": self.hosting,
+            "edition": self.edition,
+            "behind_waf": self.behind_waf,
+            "confidence": self.confidence,
+            "conflicts": self.conflicts,
+            "probes": [p.to_dict() for p in self.probes],
+        }
+
+
+def _parse_major(value: Any) -> Optional[int]:
+    if isinstance(value, int):
+        return value
+    if not value:
+        return None
+    m = _MAJOR_VERSION_RE.search(str(value))
+    return int(m.group(1)) if m else None
+
+
+def _timed(fn):
+    """Wrap a sync probe so it records its own latency + catches exceptions."""
+
+    def wrapper(*args, **kwargs) -> ProbeResult:
+        name = fn.__name__.replace("_probe_", "")
+        t0 = perf_counter()
+        try:
+            return fn(*args, **kwargs)
+        except Exception as e:  # safety net: probes must never crash the runner
+            return ProbeResult(
+                name=name,
+                ok=False,
+                latency_ms=int((perf_counter() - t0) * 1000),
+                error=f"{type(e).__name__}: {e}",
+            )
+
+    wrapper.__name__ = fn.__name__
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Probes
+# ---------------------------------------------------------------------------
+
+
+@_timed
+def _probe_xmlrpc_version(url: str, timeout: int) -> ProbeResult:
+    """P1: XML-RPC common.version(). Uses stdlib http.client TLS fingerprint."""
+    t0 = perf_counter()
+    proxy = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/common", allow_none=True)
+    info = proxy.version()  # may raise on TLS reject / 4xx / timeout
+    sv = info.get("server_version", "")
+    svi = info.get("server_version_info") or []
+    major = _parse_major(svi[0] if svi else None) or _parse_major(sv)
+    return ProbeResult(
+        name="xmlrpc_version",
+        ok=bool(major),
+        latency_ms=int((perf_counter() - t0) * 1000),
+        summary={"server_version": sv, "major": major, "raw_info": svi[:6]},
+    )
+
+
+@_timed
+def _probe_web_version(url: str, timeout: int) -> ProbeResult:
+    """P2: GET /web/version with Chrome TLS — works through Cloudflare."""
+    t0 = perf_counter()
+    r = cffi_requests.get(
+        f"{url}/web/version",
+        impersonate=_IMPERSONATE,
+        timeout=timeout,
+        allow_redirects=True,
+    )
+    summary: Dict[str, Any] = {}
+    if r.status_code == 200:
+        try:
+            data = r.json()
+            sv = data.get("version") or data.get("server_version", "")
+            svi = data.get("version_info") or data.get("server_version_info") or []
+            summary = {
+                "server_version": sv,
+                "major": _parse_major(svi[0] if svi else None) or _parse_major(sv),
+                "raw_info": svi[:6],
+            }
+        except Exception:
+            summary = {"body_snippet": r.text[:200]}
+    return ProbeResult(
+        name="web_version",
+        ok=r.status_code == 200 and bool(summary.get("major")),
+        latency_ms=int((perf_counter() - t0) * 1000),
+        status_code=r.status_code,
+        summary=summary,
+    )
+
+
+@_timed
+def _probe_web_health(url: str, timeout: int) -> ProbeResult:
+    """GET /web/health — Odoo 17+ returns 200 with 'pass' in the body."""
+    t0 = perf_counter()
+    r = cffi_requests.get(
+        f"{url}/web/health",
+        impersonate=_IMPERSONATE,
+        timeout=timeout,
+        allow_redirects=True,
+    )
+    text = (r.text or "")[:300]
+    is_odoo_health = r.status_code == 200 and "pass" in text
+    return ProbeResult(
+        name="web_health",
+        ok=is_odoo_health,
+        latency_ms=int((perf_counter() - t0) * 1000),
+        status_code=r.status_code,
+        summary={"has_pass_marker": is_odoo_health, "body_snippet": text[:120]},
+    )
+
+
+@_timed
+def _probe_web_login(url: str, timeout: int) -> ProbeResult:
+    """GET /web/login — looks for Odoo HTML markers + the db_monodb cookie."""
+    t0 = perf_counter()
+    r = cffi_requests.get(
+        f"{url}/web/login",
+        impersonate=_IMPERSONATE,
+        timeout=timeout,
+        allow_redirects=True,
+    )
+    text_low = (r.text or "").lower()
+    has_o_login = "o_login" in text_low or "o_database_list" in text_low
+    has_odoo_word = "odoo" in text_low
+    cookies = r.cookies if hasattr(r, "cookies") else {}
+    db_monodb = None
+    try:
+        db_monodb = cookies.get("db_monodb") if cookies else None  # type: ignore[union-attr]
+    except Exception:
+        pass
+    return ProbeResult(
+        name="web_login",
+        ok=r.status_code == 200 and (has_o_login or has_odoo_word),
+        latency_ms=int((perf_counter() - t0) * 1000),
+        status_code=r.status_code,
+        summary={
+            "has_o_login_class": has_o_login,
+            "has_odoo_word": has_odoo_word,
+            "db_monodb_cookie": db_monodb,
+        },
+    )
+
+
+@_timed
+def _probe_root_headers(url: str, timeout: int) -> ProbeResult:
+    """HEAD / — read the `server:` header. 'Odoo.sh' / 'nginx' / 'cloudflare'."""
+    t0 = perf_counter()
+    r = cffi_requests.request(
+        "HEAD",
+        url,
+        impersonate=_IMPERSONATE,
+        timeout=timeout,
+        allow_redirects=True,
+    )
+    server = ""
+    try:
+        server = (r.headers.get("server") or "").strip()
+    except Exception:
+        pass
+    return ProbeResult(
+        name="root_headers",
+        ok=bool(server),
+        latency_ms=int((perf_counter() - t0) * 1000),
+        status_code=r.status_code,
+        summary={"server": server, "behind_cloudflare": "cloudflare" in server.lower()},
+    )
+
+
+@_timed
+def _probe_jsonrpc_version(url: str, timeout: int) -> ProbeResult:
+    """POST /jsonrpc common.version — Odoo's pre-19 JSON-RPC equivalent of XML-RPC."""
+    t0 = perf_counter()
+    body = {
+        "jsonrpc": "2.0",
+        "method": "call",
+        "params": {"service": "common", "method": "version", "args": []},
+    }
+    r = cffi_requests.post(
+        f"{url}/jsonrpc",
+        json=body,
+        impersonate=_IMPERSONATE,
+        timeout=timeout,
+        allow_redirects=True,
+    )
+    summary: Dict[str, Any] = {}
+    if r.status_code == 200:
+        try:
+            data = r.json()
+            result = data.get("result") or {}
+            sv = result.get("server_version", "")
+            svi = result.get("server_version_info") or []
+            summary = {
+                "server_version": sv,
+                "major": _parse_major(svi[0] if svi else None) or _parse_major(sv),
+                "raw_info": svi[:6],
+            }
+        except Exception:
+            summary = {"body_snippet": r.text[:200]}
+    return ProbeResult(
+        name="jsonrpc_version",
+        ok=r.status_code == 200 and bool(summary.get("major")),
+        latency_ms=int((perf_counter() - t0) * 1000),
+        status_code=r.status_code,
+        summary=summary,
+    )
+
+
+@_timed
+def _probe_json2_unauth(url: str, timeout: int) -> ProbeResult:
+    """POST /json/2/res.users/context_get without auth.
+
+    Odoo 19+ replies 401 with `name: werkzeug.exceptions.Unauthorized` and
+    message "Invalid apikey". That's a strong "JSON/2 endpoint is live" signal,
+    so the server is v19+. Pre-v19 returns 404.
+    """
+    t0 = perf_counter()
+    r = cffi_requests.post(
+        f"{url}/json/2/res.users/context_get",
+        json={},
+        impersonate=_IMPERSONATE,
+        timeout=timeout,
+        allow_redirects=True,
+    )
+    summary: Dict[str, Any] = {"status_code": r.status_code}
+    supports_json2 = False
+    try:
+        # Either 401 with Odoo error envelope, or 200 (in dev/no-auth setups
+        # which we don't expect in the wild but accept as positive).
+        if r.status_code in (401, 200):
+            body = r.json()
+            name = (body or {}).get("name", "") if isinstance(body, dict) else ""
+            supports_json2 = (
+                "werkzeug" in name.lower() or "invalid apikey" in str(body).lower()
+            ) or r.status_code == 200
+            summary["error_name"] = name
+    except Exception:
+        # 401 without JSON body is still meaningful in context but harder to
+        # disambiguate from Cloudflare's challenge page. Stay conservative.
+        pass
+    summary["supports_json2"] = supports_json2
+    return ProbeResult(
+        name="json2_unauth",
+        ok=supports_json2,
+        latency_ms=int((perf_counter() - t0) * 1000),
+        status_code=r.status_code,
+        summary=summary,
+    )
+
+
+@_timed
+def _probe_dns_cloudflare(url: str, timeout: int) -> ProbeResult:
+    """Resolve the hostname and check if the IP falls in Cloudflare's ranges."""
+    t0 = perf_counter()
+    host = urlparse(url).hostname or ""
+    ip: Optional[str] = None
+    is_cf = False
+    try:
+        # gethostbyname only returns one A record — good enough for "is it CF".
+        ip = socket.gethostbyname(host)
+        addr = ipaddress.ip_address(ip)
+        if isinstance(addr, ipaddress.IPv4Address):
+            is_cf = any(addr in net for net in _CLOUDFLARE_NETS)
+    except Exception as e:
+        return ProbeResult(
+            name="dns_cloudflare",
+            ok=False,
+            latency_ms=int((perf_counter() - t0) * 1000),
+            error=f"{type(e).__name__}: {e}",
+        )
+    return ProbeResult(
+        name="dns_cloudflare",
+        ok=True,
+        latency_ms=int((perf_counter() - t0) * 1000),
+        summary={"ip": ip, "is_cloudflare": is_cf},
+    )
+
+
+_PROBES = (
+    _probe_xmlrpc_version,
+    _probe_web_version,
+    _probe_web_health,
+    _probe_web_login,
+    _probe_root_headers,
+    _probe_jsonrpc_version,
+    _probe_json2_unauth,
+    _probe_dns_cloudflare,
+)
+
+
+# ---------------------------------------------------------------------------
+# Aggregator
+# ---------------------------------------------------------------------------
+
+
+def _aggregate(probes: List[ProbeResult]) -> DetectionResult:
+    """Rule-based fusion of probe outputs into a single conclusion.
+
+    Voting strategy:
+    - is_odoo: positive if ANY of (xmlrpc_version, web_version, web_login,
+      jsonrpc_version, json2_unauth) succeeded.
+    - major version: majority vote across probes that produced a major.
+      Ties broken by preferring the highest version (forward-compat: we'd
+      rather try json2 on a v18-v19 boundary instance).
+    - api_version: json2 if json2_unauth said so OR majority major >= 19.
+    - hosting: Cloudflare server-header or CF IP range → behind_waf.
+      Server header "Odoo.sh" → sh. "saas~" version prefix → online.
+      Otherwise unknown.
+    - edition: "+e" suffix in any server_version → enterprise, else community
+      (only when at least one version probe succeeded; otherwise None).
+    - confidence: high if ≥3 probes contributed congruent signals;
+      medium with 2; low with 0 or 1.
+    """
+    by_name = {p.name: p for p in probes}
+    conflicts: List[str] = []
+
+    odoo_signals = [
+        by_name.get("xmlrpc_version"),
+        by_name.get("web_version"),
+        by_name.get("web_login"),
+        by_name.get("jsonrpc_version"),
+        by_name.get("json2_unauth"),
+    ]
+    is_odoo = any(p and p.ok for p in odoo_signals)
+
+    # Major version vote
+    majors: List[int] = []
+    server_versions: List[str] = []
+    for name in ("xmlrpc_version", "web_version", "jsonrpc_version"):
+        p = by_name.get(name)
+        if not p or not p.ok:
+            continue
+        m = p.summary.get("major")
+        sv = p.summary.get("server_version") or ""
+        if isinstance(m, int):
+            majors.append(m)
+        if sv:
+            server_versions.append(sv)
+
+    major: Optional[int] = None
+    if majors:
+        # Mode with tie-break toward highest
+        from collections import Counter
+
+        counts = Counter(majors).most_common()
+        top_count = counts[0][1]
+        tied = [v for v, c in counts if c == top_count]
+        major = max(tied)
+        if len(set(majors)) > 1:
+            conflicts.append(f"major_version_disagreement: probes returned {majors}")
+
+    # JSON/2 evidence is independently authoritative — overrides version vote
+    # when /json/2 endpoint responds, because that endpoint only exists on v19+.
+    json2_probe = by_name.get("json2_unauth")
+    json2_alive = bool(json2_probe and json2_probe.ok)
+
+    if json2_alive:
+        api_version: ApiVersion = "json2"
+        if major is not None and major < JSON2_MIN_VERSION:
+            conflicts.append(
+                f"json2_endpoint_live_but_version_probe_says_v{major}"
+            )
+            # Trust json2: the version probe is likely cached or wrong.
+            major = max(major, JSON2_MIN_VERSION)
+    elif major is not None:
+        api_version = "json2" if major >= JSON2_MIN_VERSION else "xmlrpc"
+    else:
+        api_version = "unknown"
+
+    server_version = server_versions[0] if server_versions else None
+
+    # Hosting
+    headers_probe = by_name.get("root_headers")
+    server_hdr = (headers_probe.summary.get("server") if headers_probe else "") or ""
+    dns_probe = by_name.get("dns_cloudflare")
+    is_cf_ip = bool(dns_probe and dns_probe.summary.get("is_cloudflare"))
+    is_cf_hdr = "cloudflare" in server_hdr.lower()
+    behind_waf = is_cf_ip or is_cf_hdr
+
+    hosting: Hosting
+    if behind_waf:
+        hosting = "behind_waf"
+    elif "Odoo.sh" in server_hdr:
+        hosting = "sh"
+    elif any("saas~" in sv for sv in server_versions):
+        hosting = "online"
+    elif is_odoo:
+        # nginx + non-saas version is ambiguous (could be Online or .sh).
+        # Don't claim certainty — see reference_odoo_taxonomy.md.
+        hosting = "self_hosted"
+    else:
+        hosting = "unknown"
+
+    # Edition (only meaningful when we have a version string)
+    edition: Optional[Edition] = None
+    if server_versions:
+        edition = "enterprise" if any("+e" in sv for sv in server_versions) else "community"
+
+    # Confidence: count probes that contributed to the conclusion
+    contributing = sum(
+        1
+        for p in probes
+        if p.ok and p.name in {
+            "xmlrpc_version",
+            "web_version",
+            "jsonrpc_version",
+            "json2_unauth",
+            "web_health",
+            "web_login",
+            "root_headers",
+            "dns_cloudflare",
+        }
+    )
+    if contributing >= 3:
+        confidence: Confidence = "high"
+    elif contributing == 2:
+        confidence = "medium"
+    else:
+        confidence = "low"
+
+    return DetectionResult(
+        is_odoo=is_odoo,
+        api_version=api_version,
+        server_version=server_version,
+        major=major,
+        hosting=hosting,
+        edition=edition,
+        behind_waf=behind_waf,
+        confidence=confidence,
+        probes=list(probes),
+        conflicts=conflicts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def detect_odoo(url: str, timeout: int = PROBE_TIMEOUT_SECONDS) -> DetectionResult:
+    """Fire every probe in parallel and aggregate the evidence."""
+    url = url.rstrip("/")
+    loop = asyncio.get_event_loop()
+    with ThreadPoolExecutor(max_workers=len(_PROBES)) as pool:
+        tasks = [loop.run_in_executor(pool, p, url, timeout) for p in _PROBES]
+        probes: List[ProbeResult] = list(await asyncio.gather(*tasks))
+    result = _aggregate(probes)
+    logger.info(
+        "Detected %s: api=%s major=%s hosting=%s waf=%s confidence=%s "
+        "(probes_ok=%d/%d)",
+        url,
+        result.api_version,
+        result.major,
+        result.hosting,
+        result.behind_waf,
+        result.confidence,
+        sum(1 for p in probes if p.ok),
+        len(probes),
+    )
+    return result
+
+
+def detect_odoo_sync(url: str, timeout: int = PROBE_TIMEOUT_SECONDS) -> DetectionResult:
+    """Sync convenience wrapper around `detect_odoo`."""
+    return asyncio.run(detect_odoo(url, timeout))
+
+
+def detect_api_version(
+    odoo_url: str,
+    timeout: int = PROBE_TIMEOUT_SECONDS,
+) -> Tuple[ApiVersion, Optional[str]]:
+    """Back-compat shim that returns just (api_version, server_version).
+
+    Existing callers (server.py, registry.py) don't need the full evidence
+    matrix; they just want to know which connection class to instantiate.
+    They get that here; the admin layer calls `detect_odoo` directly to
+    persist the evidence.
+    """
+    result = detect_odoo_sync(odoo_url, timeout)
+    return result.api_version, result.server_version

--- a/mcp_server_odoo/odoo_json2_connection.py
+++ b/mcp_server_odoo/odoo_json2_connection.py
@@ -13,7 +13,8 @@ import logging
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
-import httpx
+from curl_cffi import requests as cffi_requests
+from curl_cffi.requests.errors import RequestsError
 
 from .config import OdooConfig
 from .error_sanitizer import ErrorSanitizer
@@ -66,8 +67,10 @@ class OdooJSON2Connection:
         self._database: Optional[str] = None
         self._version: Optional[Dict[str, Any]] = None
 
-        # httpx client (created on connect)
-        self._client: Optional[httpx.Client] = None
+        # HTTP client (created on connect). curl_cffi with browser-TLS
+        # impersonation, so customer-side WAFs (Cloudflare bot-detection in
+        # particular) don't reject us on TLS fingerprint.
+        self._client: Optional[cffi_requests.Session] = None
 
         # Field cache
         self._fields_cache: Dict[str, Dict[str, Dict[str, Any]]] = {}
@@ -117,13 +120,14 @@ class OdooJSON2Connection:
 
         try:
             response = self._client.post(url, json=body)
-        except httpx.TimeoutException:
-            raise OdooConnectionError(
-                f"Request timeout after {self.timeout}s: {model}/{method}"
-            ) from None
-        except httpx.ConnectError as e:
-            raise OdooConnectionError(f"Connection failed: {e}") from e
-        except httpx.HTTPError as e:
+        except RequestsError as e:
+            msg = str(e).lower()
+            if "timeout" in msg or "timed out" in msg:
+                raise OdooConnectionError(
+                    f"Request timeout after {self.timeout}s: {model}/{method}"
+                ) from None
+            if "resolve" in msg or "connect" in msg:
+                raise OdooConnectionError(f"Connection failed: {e}") from e
             raise OdooConnectionError(f"HTTP error: {e}") from e
 
         # Handle error responses
@@ -144,7 +148,7 @@ class OdooJSON2Connection:
         else:
             raise OdooConnectionError(f"Server error ({response.status_code}): {error_msg}")
 
-    def _parse_error_response(self, response: httpx.Response) -> str:
+    def _parse_error_response(self, response: Any) -> str:
         """Extract error message from a JSON/2 error response.
 
         JSON/2 error responses contain:
@@ -168,8 +172,8 @@ class OdooJSON2Connection:
     def connect(self) -> None:
         """Establish connection to Odoo server.
 
-        Creates an httpx client and verifies the server is reachable
-        by fetching the version endpoint.
+        Creates a curl_cffi session with Chrome TLS impersonation and
+        verifies the server is reachable by fetching the version endpoint.
 
         Raises:
             OdooConnectionError: If connection fails
@@ -179,16 +183,22 @@ class OdooJSON2Connection:
             return
 
         try:
-            self._client = httpx.Client(
+            self._client = cffi_requests.Session(
+                impersonate="chrome",
                 timeout=self.timeout,
-                follow_redirects=True,
+                allow_redirects=True,
             )
 
             # Test connection by fetching server version
             self._version = self._fetch_version()
             self._connected = True
 
-            version_str = self._version.get("server_version", "unknown")
+            # /web/version returns {"version": ..., "version_info": [...]}
+            # while xmlrpc /common.version() returns {"server_version": ...}.
+            # Accept either to keep the log useful regardless of source.
+            version_str = self._version.get("version") or self._version.get(
+                "server_version", "unknown"
+            )
             logger.info(f"Connected to Odoo {version_str}")
 
         except OdooConnectionError:
@@ -209,14 +219,17 @@ class OdooJSON2Connection:
         """
         try:
             response = self._client.get(f"{self._base_url}/web/version")
-            response.raise_for_status()
-            return response.json()
-        except httpx.HTTPStatusError as e:
-            raise OdooConnectionError(
-                f"Failed to fetch server version: HTTP {e.response.status_code}"
-            ) from e
-        except Exception as e:
+        except RequestsError as e:
             raise OdooConnectionError(f"Failed to fetch server version: {e}") from e
+
+        if response.status_code != 200:
+            raise OdooConnectionError(
+                f"Failed to fetch server version: HTTP {response.status_code}"
+            )
+        try:
+            return response.json()
+        except Exception as e:
+            raise OdooConnectionError(f"Failed to parse server version response: {e}") from e
 
     def disconnect(self) -> None:
         """Close connection and cleanup resources."""
@@ -233,7 +246,7 @@ class OdooJSON2Connection:
         logger.info("Disconnected from Odoo server")
 
     def _cleanup_client(self) -> None:
-        """Close the httpx client if open."""
+        """Close the HTTP client if open."""
         if self._client:
             try:
                 self._client.close()

--- a/mcp_server_odoo/registry.py
+++ b/mcp_server_odoo/registry.py
@@ -110,6 +110,22 @@ class ConnectionRegistry:
                 f"(Error: {e})"
             ) from e
 
+        if api_version == "unknown":
+            # Both probes failed but we don't have a UI to ask the user from
+            # here. Use the version explicitly stored on the connection if any,
+            # otherwise fall back to xmlrpc and let authenticate() surface a
+            # real reason. The admin setup wizard should have asked the user
+            # already; reaching this branch means setup was skipped or stale.
+            stored = (user_conn.odoo_version or "").lower()
+            if "saas~" in stored or stored.startswith("19") or "19." in stored:
+                api_version = "json2"
+            else:
+                api_version = "xmlrpc"
+            logger.warning(
+                f"Auto-detection failed for {user_conn.odoo_url}; "
+                f"using stored version '{user_conn.odoo_version}' -> {api_version}"
+            )
+
         logger.info(
             f"Auto-detected api_version={api_version} for {user_conn.odoo_url}"
             f" (Odoo {server_version or 'unknown'})"

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -657,6 +657,16 @@ class OdooMCPServer:
                 with perf_logger.track_operation("connection_setup"):
                     # Auto-detect API version from Odoo server version
                     api_version, server_version = detect_api_version(self.config.url)
+                    if api_version == "unknown":
+                        # Both XML-RPC and /web/version probes failed. In OSS
+                        # standalone usage we have no UI to ask the user, so
+                        # fall back to xmlrpc and let authenticate() raise with
+                        # the real reason.
+                        logger.warning(
+                            "Could not auto-detect Odoo version; falling back to xmlrpc. "
+                            "If you are on Odoo 19+, set ODOO_API_VERSION=json2 explicitly."
+                        )
+                        api_version = "xmlrpc"
                     self.config.api_version = api_version
                     logger.info(
                         f"Auto-detected api_version={api_version}"

--- a/mcp_server_odoo/version_detect.py
+++ b/mcp_server_odoo/version_detect.py
@@ -151,9 +151,7 @@ def detect_api_version(
     result = _detect_via_xmlrpc(url, timeout)
     if result is not None:
         api_version, server_version = result
-        logger.info(
-            f"Detected Odoo {server_version} via xmlrpc -> api_version={api_version}"
-        )
+        logger.info(f"Detected Odoo {server_version} via xmlrpc -> api_version={api_version}")
         return api_version, server_version
 
     result = _detect_via_web_version(url, timeout)

--- a/mcp_server_odoo/version_detect.py
+++ b/mcp_server_odoo/version_detect.py
@@ -1,13 +1,29 @@
 """Auto-detect Odoo API version from server version.
 
-Probes the Odoo server via XML-RPC (works on all versions 14+)
-and returns the appropriate API version string.
+Probes the Odoo server via two independent paths and returns the
+appropriate API version string:
+
+1. **P1** — `xmlrpc.client.version()` against `/xmlrpc/2/common`. Stdlib,
+   fast, no extra deps. Works on every Odoo from 14+ that exposes XML-RPC.
+   Its stdlib TLS fingerprint usually slips past Cloudflare bot-detection.
+
+2. **P2** — `curl_cffi.get('/web/version')` with Chrome impersonation.
+   Slower fallback, but Chrome-spoofed TLS passes through every WAF we've
+   observed in production. Used when P1 raises any exception or when the
+   response is unparseable.
+
+If both fail, we return `("unknown", None)`. Callers can then either fall
+back to a default (server.py treats unknown as xmlrpc) or surface a user
+prompt (admin setup wizard asks the user to pick a version).
 """
 
 import logging
 import re
 import xmlrpc.client
 from typing import Literal, Optional, Tuple
+
+from curl_cffi import requests as cffi_requests
+from curl_cffi.requests.errors import RequestsError
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +32,8 @@ JSON2_MIN_VERSION = 19
 
 # Regex to extract the major version number from strings like "saas~19", "19", "19.0"
 _MAJOR_VERSION_RE = re.compile(r"(\d+)")
+
+ApiVersion = Literal["json2", "xmlrpc", "unknown"]
 
 
 def _parse_major(value) -> int:
@@ -31,55 +49,124 @@ def _parse_major(value) -> int:
     raise ValueError(f"Cannot parse major version from {value!r}")
 
 
-def detect_api_version(
-    odoo_url: str,
-    timeout: int = 10,
-) -> Tuple[Literal["json2", "xmlrpc"], Optional[str]]:
-    """Detect the appropriate API version for an Odoo server.
+def _api_version_for(major: int) -> Literal["json2", "xmlrpc"]:
+    return "json2" if major >= JSON2_MIN_VERSION else "xmlrpc"
 
-    Makes a lightweight XML-RPC call to /xmlrpc/2/common version()
-    which works on all Odoo versions without authentication.
 
-    Args:
-        odoo_url: Base URL of the Odoo server (e.g., "https://mycompany.odoo.com")
-        timeout: Connection timeout in seconds
+def _detect_via_xmlrpc(url: str, timeout: int) -> Optional[Tuple[Literal["json2", "xmlrpc"], str]]:
+    """P1: XML-RPC version() probe. Returns None on any failure."""
+    try:
+        proxy = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/common", allow_none=True)
+        info = proxy.version()
+    except Exception as e:
+        logger.info(f"xmlrpc probe failed at {url}: {e}")
+        return None
 
-    Returns:
-        Tuple of (api_version, server_version_string).
-        api_version is "json2" for Odoo 19+, "xmlrpc" for older versions.
-        server_version_string is e.g. "19.0" or None if detection failed.
-
-    Falls back to "xmlrpc" if detection fails.
-    """
-    url = odoo_url.rstrip("/")
-    endpoint = f"{url}/xmlrpc/2/common"
+    server_version = info.get("server_version", "")
+    server_version_info = info.get("server_version_info", [])
 
     try:
-        proxy = xmlrpc.client.ServerProxy(endpoint, allow_none=True)
-        # Socket timeout via transport isn't straightforward with ServerProxy,
-        # so we use a simple approach: create with default and rely on system timeout.
-        # For more control, we could use httpx, but xmlrpc.client is sufficient here.
-        version_info = proxy.version()
-
-        server_version = version_info.get("server_version", "")
-        server_version_info = version_info.get("server_version_info", [])
-
-        # Parse major version from server_version_info [major, minor, micro, release, serial]
-        # Odoo.sh SaaS versions use strings like "saas~19" instead of int 19
         if server_version_info and len(server_version_info) >= 1:
             major = _parse_major(server_version_info[0])
         elif server_version:
             major = _parse_major(server_version.split(".")[0])
         else:
-            logger.warning("Could not parse Odoo version, falling back to xmlrpc")
-            return "xmlrpc", None
+            return None
+    except ValueError:
+        return None
 
-        api_version: Literal["json2", "xmlrpc"] = (
-            "json2" if major >= JSON2_MIN_VERSION else "xmlrpc"
+    return _api_version_for(major), server_version
+
+
+def _detect_via_web_version(
+    url: str, timeout: int
+) -> Optional[Tuple[Literal["json2", "xmlrpc"], str]]:
+    """P2: GET /web/version via curl_cffi (Chrome TLS).
+
+    Used when XML-RPC probe fails — most commonly because of customer-side
+    Cloudflare rejecting our stdlib TLS fingerprint. Browser-impersonated
+    TLS passes through.
+
+    Returns None if the endpoint also blocks us or the response is unusable.
+    """
+    try:
+        resp = cffi_requests.get(
+            f"{url}/web/version",
+            impersonate="chrome",
+            timeout=timeout,
+            allow_redirects=True,
         )
-        logger.info(f"Detected Odoo {server_version} (major={major}) -> api_version={api_version}")
+    except RequestsError as e:
+        logger.info(f"/web/version probe failed at {url}: {e}")
+        return None
+
+    if resp.status_code != 200:
+        logger.info(f"/web/version returned {resp.status_code} at {url}")
+        return None
+
+    try:
+        data = resp.json()
+    except Exception:
+        return None
+
+    # /web/version returns {"version": "saas~19.2+e", "version_info": [...]}
+    server_version = data.get("version") or data.get("server_version", "")
+    version_info = data.get("version_info") or data.get("server_version_info") or []
+
+    try:
+        if version_info and len(version_info) >= 1:
+            major = _parse_major(version_info[0])
+        elif server_version:
+            major = _parse_major(server_version.split(".")[0])
+        else:
+            return None
+    except ValueError:
+        return None
+
+    return _api_version_for(major), server_version
+
+
+def detect_api_version(
+    odoo_url: str,
+    timeout: int = 10,
+) -> Tuple[ApiVersion, Optional[str]]:
+    """Detect the appropriate API version for an Odoo server.
+
+    Tries XML-RPC first, then /web/version via curl_cffi as a Cloudflare-aware
+    fallback. Returns ("unknown", None) when both probes fail — callers should
+    either default to xmlrpc (OSS standalone) or ask the user (admin wizard).
+
+    Args:
+        odoo_url: Base URL of the Odoo server (e.g., "https://mycompany.odoo.com")
+        timeout: Per-probe connection timeout in seconds
+
+    Returns:
+        Tuple of (api_version, server_version_string).
+        api_version is "json2" for Odoo 19+, "xmlrpc" for older versions,
+        "unknown" if both probes failed.
+        server_version_string is e.g. "saas~19.2+e" or None when unknown.
+    """
+    url = odoo_url.rstrip("/")
+
+    result = _detect_via_xmlrpc(url, timeout)
+    if result is not None:
+        api_version, server_version = result
+        logger.info(
+            f"Detected Odoo {server_version} via xmlrpc -> api_version={api_version}"
+        )
         return api_version, server_version
 
-    except Exception as e:
-        logger.warning(f"Failed to detect Odoo version at {url}: {e}. Falling back to xmlrpc.")
-        return "xmlrpc", None
+    result = _detect_via_web_version(url, timeout)
+    if result is not None:
+        api_version, server_version = result
+        logger.info(
+            f"Detected Odoo {server_version} via /web/version (curl_cffi) "
+            f"-> api_version={api_version}"
+        )
+        return api_version, server_version
+
+    logger.warning(
+        f"Both detection probes failed at {url}. Returning 'unknown' so the "
+        f"caller can prompt the user."
+    )
+    return "unknown", None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 dependencies = [
     "mcp>=1.26.0,<2",
     "httpx>=0.27.0",
+    "curl_cffi>=0.7.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -198,11 +198,7 @@ class TestDetectOdooSync:
             lambda url, t, n=p.__name__: self._make_probe_result(
                 n.replace("_probe_", ""),
                 ok=True,
-                **(
-                    {"server_version": "saas~19.2+e", "major": 19}
-                    if "version" in n
-                    else {}
-                ),
+                **({"server_version": "saas~19.2+e", "major": 19} if "version" in n else {}),
             )
             for p in detection._PROBES
         ]

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1,0 +1,213 @@
+"""Tests for the shotgun detection module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_server_odoo.detection import (
+    DetectionResult,
+    ProbeResult,
+    _aggregate,
+    _parse_major,
+    detect_odoo_sync,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure aggregator tests — no I/O
+# ---------------------------------------------------------------------------
+
+
+def _ok(name: str, **summary) -> ProbeResult:
+    return ProbeResult(name=name, ok=True, latency_ms=100, summary=summary)
+
+
+def _fail(name: str, status_code=None) -> ProbeResult:
+    return ProbeResult(name=name, ok=False, latency_ms=100, status_code=status_code)
+
+
+class TestAggregator:
+    """The aggregator is a pure function over ProbeResult lists."""
+
+    def test_v19_online_happy_path(self):
+        probes = [
+            _ok("xmlrpc_version", server_version="saas~19.2+e", major=19),
+            _ok("web_version", server_version="saas~19.2+e", major=19),
+            _ok("jsonrpc_version", server_version="saas~19.2+e", major=19),
+            _ok("json2_unauth", supports_json2=True),
+            _ok("root_headers", server="nginx"),
+            _ok("dns_cloudflare", ip="1.2.3.4", is_cloudflare=False),
+        ]
+        r = _aggregate(probes)
+        assert r.is_odoo
+        assert r.api_version == "json2"
+        assert r.major == 19
+        assert r.server_version == "saas~19.2+e"
+        assert r.hosting == "online"
+        assert r.edition == "enterprise"
+        assert not r.behind_waf
+        assert r.confidence == "high"
+        assert r.conflicts == []
+
+    def test_v18_self_hosted(self):
+        probes = [
+            _ok("xmlrpc_version", server_version="18.0+e", major=18),
+            _ok("jsonrpc_version", server_version="18.0+e", major=18),
+            _fail("json2_unauth", status_code=404),
+            _ok("root_headers", server="Werkzeug"),
+            _ok("dns_cloudflare", is_cloudflare=False),
+        ]
+        r = _aggregate(probes)
+        assert r.api_version == "xmlrpc"
+        assert r.major == 18
+        assert r.hosting == "self_hosted"
+        assert r.edition == "enterprise"
+
+    def test_behind_cloudflare_by_dns(self):
+        probes = [
+            _ok("web_version", server_version="saas~19.2+e", major=19),
+            _ok("json2_unauth", supports_json2=True),
+            _ok("dns_cloudflare", ip="104.21.13.7", is_cloudflare=True),
+            _ok("root_headers", server="cloudflare"),
+        ]
+        r = _aggregate(probes)
+        assert r.behind_waf
+        assert r.hosting == "behind_waf"
+        assert r.api_version == "json2"
+
+    def test_odoo_sh_via_server_header(self):
+        probes = [
+            _ok("xmlrpc_version", server_version="19.0+e", major=19),
+            _ok("root_headers", server="Odoo.sh"),
+            _ok("dns_cloudflare", is_cloudflare=False),
+        ]
+        r = _aggregate(probes)
+        assert r.hosting == "sh"
+
+    def test_json2_endpoint_overrides_version_vote(self):
+        """If /json/2 responds, treat the instance as v19+ even if version
+        probes are cached and say v18 (real production gotcha)."""
+        probes = [
+            _ok("xmlrpc_version", server_version="18.0+e", major=18),
+            _ok("json2_unauth", supports_json2=True),
+            _ok("root_headers", server="nginx"),
+        ]
+        r = _aggregate(probes)
+        assert r.api_version == "json2"
+        assert r.major >= 19
+        assert any("json2_endpoint_live" in c for c in r.conflicts)
+
+    def test_disagreement_in_major_recorded_as_conflict(self):
+        probes = [
+            _ok("xmlrpc_version", server_version="19.0+e", major=19),
+            _ok("web_version", server_version="18.0+e", major=18),
+            _fail("json2_unauth"),
+        ]
+        r = _aggregate(probes)
+        # Tie broken by max
+        assert r.major == 19
+        assert any("disagreement" in c for c in r.conflicts)
+
+    def test_no_probes_succeeded_returns_unknown(self):
+        probes = [
+            _fail("xmlrpc_version"),
+            _fail("web_version"),
+            _fail("web_health"),
+            _fail("web_login"),
+            _fail("jsonrpc_version"),
+            _fail("json2_unauth"),
+            _fail("root_headers"),
+            _fail("dns_cloudflare"),
+        ]
+        r = _aggregate(probes)
+        assert not r.is_odoo
+        assert r.api_version == "unknown"
+        assert r.major is None
+        assert r.hosting == "unknown"
+        assert r.confidence == "low"
+
+    def test_only_dns_and_headers_no_odoo(self):
+        """Reachable host but no Odoo markers."""
+        probes = [
+            _fail("xmlrpc_version"),
+            _fail("web_version", status_code=200),  # ok=False because no major
+            _ok("dns_cloudflare", ip="1.2.3.4", is_cloudflare=False),
+            _ok("root_headers", server="Apache"),
+        ]
+        r = _aggregate(probes)
+        assert not r.is_odoo
+        assert r.api_version == "unknown"
+
+    def test_confidence_medium_with_two_probes(self):
+        probes = [
+            _ok("xmlrpc_version", server_version="19.0+e", major=19),
+            _ok("root_headers", server="nginx"),
+            _fail("web_version"),
+            _fail("json2_unauth"),
+        ]
+        r = _aggregate(probes)
+        assert r.confidence == "medium"
+
+    def test_to_dict_round_trips(self):
+        probes = [_ok("xmlrpc_version", server_version="19.0+e", major=19)]
+        r = _aggregate(probes)
+        d = r.to_dict()
+        # major=19 -> json2 even without a live json2 probe; the json2
+        # endpoint becomes the override when present, not a requirement.
+        assert d["api_version"] == "json2"
+        assert d["major"] == 19
+        assert d["server_version"] == "19.0+e"
+        assert "probes" in d and len(d["probes"]) == 1
+
+
+class TestParseMajor:
+    def test_int_passthrough(self):
+        assert _parse_major(19) == 19
+
+    def test_saas_string(self):
+        assert _parse_major("saas~19.2+e") == 19
+
+    def test_dotted_string(self):
+        assert _parse_major("19.0") == 19
+
+    def test_none_returns_none(self):
+        assert _parse_major(None) is None
+
+    def test_empty_returns_none(self):
+        assert _parse_major("") is None
+
+    def test_garbage_returns_none(self):
+        assert _parse_major("not-a-version") is None
+
+
+# ---------------------------------------------------------------------------
+# detect_odoo_sync with mocked probes — confirms wiring works end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestDetectOdooSync:
+    """Mock the probe functions so the runner doesn't hit the network."""
+
+    def _make_probe_result(self, name, ok=True, **summary):
+        return ProbeResult(name=name, ok=ok, latency_ms=42, summary=summary)
+
+    def test_all_probes_run_and_aggregate(self):
+        from mcp_server_odoo import detection
+
+        fake_probes = [
+            lambda url, t, n=p.__name__: self._make_probe_result(
+                n.replace("_probe_", ""),
+                ok=True,
+                **(
+                    {"server_version": "saas~19.2+e", "major": 19}
+                    if "version" in n
+                    else {}
+                ),
+            )
+            for p in detection._PROBES
+        ]
+        with patch.object(detection, "_PROBES", tuple(fake_probes)):
+            r = detect_odoo_sync("https://example.odoo.com")
+        assert r.is_odoo
+        assert r.major == 19
+        assert len(r.probes) == len(detection._PROBES)

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1,17 +1,13 @@
 """Tests for the shotgun detection module."""
 
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import patch
 
 from mcp_server_odoo.detection import (
-    DetectionResult,
     ProbeResult,
     _aggregate,
     _parse_major,
     detect_odoo_sync,
 )
-
 
 # ---------------------------------------------------------------------------
 # Pure aggregator tests — no I/O

--- a/tests/test_json2_connection.py
+++ b/tests/test_json2_connection.py
@@ -1,14 +1,15 @@
 """Tests for OdooJSON2Connection.
 
-Unit tests use mocked httpx.Client; integration tests require
+Unit tests use a mocked curl_cffi Session; integration tests require
 a running Odoo 19 instance with ODOO_API_VERSION=json2.
 """
 
 import os
 from unittest.mock import MagicMock, patch
 
-import httpx
 import pytest
+from curl_cffi import requests as cffi_requests
+from curl_cffi.requests.errors import RequestsError
 
 from mcp_server_odoo.config import OdooConfig
 from mcp_server_odoo.odoo_json2_connection import OdooConnectionError, OdooJSON2Connection
@@ -31,7 +32,7 @@ def json2_config():
 
 @pytest.fixture
 def connected_json2(json2_config):
-    """Return a connected+authenticated OdooJSON2Connection with a mocked httpx client.
+    """Return a connected+authenticated OdooJSON2Connection with a mocked curl_cffi session.
 
     Yields (conn, mock_client) so tests can configure mock_client.post / .get.
     """
@@ -41,7 +42,7 @@ def connected_json2(json2_config):
     conn._uid = 2
     conn._database = "testdb"
 
-    mock_client = MagicMock(spec=httpx.Client)
+    mock_client = MagicMock(spec=cffi_requests.Session)
     # Default headers as a regular dict so .update() works
     mock_client.headers = {}
     conn._client = mock_client
@@ -49,16 +50,16 @@ def connected_json2(json2_config):
 
 
 def _ok_response(json_data):
-    """Build a mock httpx.Response with status 200."""
-    resp = MagicMock(spec=httpx.Response)
+    """Build a mock Response with status 200."""
+    resp = MagicMock()
     resp.status_code = 200
     resp.json.return_value = json_data
     return resp
 
 
 def _error_response(status_code, json_data=None, text="error"):
-    """Build a mock httpx.Response with an error status."""
-    resp = MagicMock(spec=httpx.Response)
+    """Build a mock Response with an error status."""
+    resp = MagicMock()
     resp.status_code = status_code
     resp.text = text
     if json_data is not None:
@@ -161,13 +162,13 @@ class TestOdooJSON2Call:
 
     def test_call_timeout_raises(self, connected_json2):
         conn, mock_client = connected_json2
-        mock_client.post.side_effect = httpx.TimeoutException("timed out")
+        mock_client.post.side_effect = RequestsError("operation timed out")
         with pytest.raises(OdooConnectionError, match="Request timeout"):
             conn._call("res.partner", "search", domain=[])
 
     def test_call_connect_error_raises(self, connected_json2):
         conn, mock_client = connected_json2
-        mock_client.post.side_effect = httpx.ConnectError("refused")
+        mock_client.post.side_effect = RequestsError("could not connect to host")
         with pytest.raises(OdooConnectionError, match="Connection failed"):
             conn._call("res.partner", "search", domain=[])
 
@@ -195,9 +196,11 @@ class TestOdooJSON2Lifecycle:
         conn = OdooJSON2Connection(json2_config)
 
         with patch.object(conn, "_fetch_version", return_value={"server_version": "19.0"}):
-            with patch("httpx.Client") as mock_client_cls:
+            with patch(
+                "mcp_server_odoo.odoo_json2_connection.cffi_requests.Session"
+            ) as mock_session_cls:
                 mock_instance = MagicMock()
-                mock_client_cls.return_value = mock_instance
+                mock_session_cls.return_value = mock_instance
                 conn.connect()
 
         assert conn.is_connected
@@ -214,7 +217,7 @@ class TestOdooJSON2Lifecycle:
         conn = OdooJSON2Connection(json2_config)
 
         with patch.object(conn, "_fetch_version", side_effect=OdooConnectionError("no version")):
-            with patch("httpx.Client"):
+            with patch("mcp_server_odoo.odoo_json2_connection.cffi_requests.Session"):
                 with pytest.raises(OdooConnectionError, match="no version"):
                     conn.connect()
 
@@ -244,7 +247,7 @@ class TestOdooJSON2Lifecycle:
     def test_authenticate_no_api_key(self, json2_config):
         conn = OdooJSON2Connection(json2_config)
         conn._connected = True
-        conn._client = MagicMock(spec=httpx.Client)
+        conn._client = MagicMock(spec=cffi_requests.Session)
         conn._client.headers = {}
         conn.config.api_key = None
 

--- a/tests/test_version_detect.py
+++ b/tests/test_version_detect.py
@@ -95,9 +95,12 @@ class TestDetectApiVersion:
         mock_proxy = MagicMock()
         mock_proxy.version.side_effect = ConnectionRefusedError("refused")
 
-        with patch(
-            "mcp_server_odoo.version_detect.xmlrpc.client.ServerProxy", return_value=mock_proxy
-        ), patch("mcp_server_odoo.version_detect._detect_via_web_version", return_value=None):
+        with (
+            patch(
+                "mcp_server_odoo.version_detect.xmlrpc.client.ServerProxy", return_value=mock_proxy
+            ),
+            patch("mcp_server_odoo.version_detect._detect_via_web_version", return_value=None),
+        ):
             api_version, server_version = detect_api_version("https://unreachable.example.com")
 
         assert api_version == "unknown"
@@ -108,9 +111,12 @@ class TestDetectApiVersion:
         mock_proxy = MagicMock()
         mock_proxy.version.side_effect = TimeoutError("timeout")
 
-        with patch(
-            "mcp_server_odoo.version_detect.xmlrpc.client.ServerProxy", return_value=mock_proxy
-        ), patch("mcp_server_odoo.version_detect._detect_via_web_version", return_value=None):
+        with (
+            patch(
+                "mcp_server_odoo.version_detect.xmlrpc.client.ServerProxy", return_value=mock_proxy
+            ),
+            patch("mcp_server_odoo.version_detect._detect_via_web_version", return_value=None),
+        ):
             api_version, server_version = detect_api_version("https://slow.example.com")
 
         assert api_version == "unknown"
@@ -121,9 +127,12 @@ class TestDetectApiVersion:
         mock_proxy = MagicMock()
         mock_proxy.version.return_value = {}
 
-        with patch(
-            "mcp_server_odoo.version_detect.xmlrpc.client.ServerProxy", return_value=mock_proxy
-        ), patch("mcp_server_odoo.version_detect._detect_via_web_version", return_value=None):
+        with (
+            patch(
+                "mcp_server_odoo.version_detect.xmlrpc.client.ServerProxy", return_value=mock_proxy
+            ),
+            patch("mcp_server_odoo.version_detect._detect_via_web_version", return_value=None),
+        ):
             api_version, server_version = detect_api_version("https://mycompany.odoo.com")
 
         assert api_version == "unknown"
@@ -141,10 +150,11 @@ class TestDetectApiVersion:
             "version_info": ["saas~19", 2, 0, "final", 0, "e"],
         }
 
-        with patch(
-            "mcp_server_odoo.version_detect.xmlrpc.client.ServerProxy", return_value=mock_proxy
-        ), patch(
-            "mcp_server_odoo.version_detect.cffi_requests.get", return_value=mock_resp
+        with (
+            patch(
+                "mcp_server_odoo.version_detect.xmlrpc.client.ServerProxy", return_value=mock_proxy
+            ),
+            patch("mcp_server_odoo.version_detect.cffi_requests.get", return_value=mock_resp),
         ):
             api_version, server_version = detect_api_version("https://cf-protected.example.com")
 
@@ -160,10 +170,11 @@ class TestDetectApiVersion:
         mock_resp.status_code = 200
         mock_resp.json.return_value = {"version": "18.0", "version_info": [18, 0, 0, "final", 0]}
 
-        with patch(
-            "mcp_server_odoo.version_detect.xmlrpc.client.ServerProxy", return_value=mock_proxy
-        ), patch(
-            "mcp_server_odoo.version_detect.cffi_requests.get", return_value=mock_resp
+        with (
+            patch(
+                "mcp_server_odoo.version_detect.xmlrpc.client.ServerProxy", return_value=mock_proxy
+            ),
+            patch("mcp_server_odoo.version_detect.cffi_requests.get", return_value=mock_resp),
         ):
             api_version, server_version = detect_api_version("https://example.com")
 

--- a/tests/test_version_detect.py
+++ b/tests/test_version_detect.py
@@ -90,44 +90,85 @@ class TestDetectApiVersion:
         assert api_version == "json2"
         assert server_version == "19.0"
 
-    def test_fallback_xmlrpc_on_connection_error(self):
-        """Should fall back to xmlrpc when connection fails."""
+    def test_unknown_when_both_probes_fail(self):
+        """When xmlrpc raises AND /web/version is unreachable, return 'unknown'."""
         mock_proxy = MagicMock()
         mock_proxy.version.side_effect = ConnectionRefusedError("refused")
 
         with patch(
             "mcp_server_odoo.version_detect.xmlrpc.client.ServerProxy", return_value=mock_proxy
-        ):
+        ), patch("mcp_server_odoo.version_detect._detect_via_web_version", return_value=None):
             api_version, server_version = detect_api_version("https://unreachable.example.com")
 
-        assert api_version == "xmlrpc"
+        assert api_version == "unknown"
         assert server_version is None
 
-    def test_fallback_xmlrpc_on_timeout(self):
-        """Should fall back to xmlrpc on timeout."""
+    def test_unknown_on_timeout_with_both_probes_failing(self):
+        """xmlrpc timeout + /web/version unreachable -> unknown."""
         mock_proxy = MagicMock()
         mock_proxy.version.side_effect = TimeoutError("timeout")
 
         with patch(
             "mcp_server_odoo.version_detect.xmlrpc.client.ServerProxy", return_value=mock_proxy
-        ):
+        ), patch("mcp_server_odoo.version_detect._detect_via_web_version", return_value=None):
             api_version, server_version = detect_api_version("https://slow.example.com")
 
-        assert api_version == "xmlrpc"
+        assert api_version == "unknown"
         assert server_version is None
 
-    def test_fallback_xmlrpc_on_empty_version(self):
-        """Should fall back to xmlrpc when version info is empty."""
+    def test_unknown_when_xmlrpc_returns_empty(self):
+        """Empty xmlrpc response + /web/version unreachable -> unknown."""
         mock_proxy = MagicMock()
         mock_proxy.version.return_value = {}
 
         with patch(
             "mcp_server_odoo.version_detect.xmlrpc.client.ServerProxy", return_value=mock_proxy
-        ):
+        ), patch("mcp_server_odoo.version_detect._detect_via_web_version", return_value=None):
             api_version, server_version = detect_api_version("https://mycompany.odoo.com")
 
-        assert api_version == "xmlrpc"
+        assert api_version == "unknown"
         assert server_version is None
+
+    def test_web_version_fallback_when_xmlrpc_fails(self):
+        """xmlrpc 301/connection-error -> /web/version succeeds with curl_cffi."""
+        mock_proxy = MagicMock()
+        mock_proxy.version.side_effect = ConnectionError("301 Moved Permanently")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "version": "saas~19.2+e",
+            "version_info": ["saas~19", 2, 0, "final", 0, "e"],
+        }
+
+        with patch(
+            "mcp_server_odoo.version_detect.xmlrpc.client.ServerProxy", return_value=mock_proxy
+        ), patch(
+            "mcp_server_odoo.version_detect.cffi_requests.get", return_value=mock_resp
+        ):
+            api_version, server_version = detect_api_version("https://cf-protected.example.com")
+
+        assert api_version == "json2"
+        assert server_version == "saas~19.2+e"
+
+    def test_web_version_fallback_returns_xmlrpc_for_v18(self):
+        """xmlrpc fails -> /web/version returns v18 -> xmlrpc."""
+        mock_proxy = MagicMock()
+        mock_proxy.version.side_effect = ConnectionError("blocked")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"version": "18.0", "version_info": [18, 0, 0, "final", 0]}
+
+        with patch(
+            "mcp_server_odoo.version_detect.xmlrpc.client.ServerProxy", return_value=mock_proxy
+        ), patch(
+            "mcp_server_odoo.version_detect.cffi_requests.get", return_value=mock_resp
+        ):
+            api_version, server_version = detect_api_version("https://example.com")
+
+        assert api_version == "xmlrpc"
+        assert server_version == "18.0"
 
     def test_url_trailing_slash_stripped(self):
         """Should strip trailing slash from URL."""


### PR DESCRIPTION
## Summary

Customers behind their own Cloudflare proxy cannot complete connection
setup. Two layers of fix:

### Layer 1 — make the HTTP client and detection ladder Cloudflare-aware
- **`Json2Connection`**: `httpx.Client` → `curl_cffi.Session(impersonate="chrome")`.
  Chrome TLS spoofing slips through CF bot-detection so auth calls
  reach Odoo's own auth layer instead of getting 403 challenges.
- **`version_detect.detect_api_version`**: add P2 fallback
  (`curl_cffi.get('/web/version')`) when the stdlib `xmlrpc.client`
  probe is blocked or rewritten. Return new `"unknown"` sentinel
  when both fail.
- Pre-existing log bug fix: `/web/version` returns `{"version": ...}`
  not `{"server_version": ...}` — the connect log used to say
  "Connected to Odoo unknown" silently.

### Layer 2 — shotgun detection (new `mcp_server_odoo/detection.py`)
Replaces the sequential probe-or-fallback ladder with 8 parallel
probes whose outputs are aggregated into a single `DetectionResult`:

1. `xmlrpc_version`   — stdlib XML-RPC on `/xmlrpc/2/common`
2. `web_version`      — GET `/web/version` (curl_cffi Chrome TLS)
3. `web_health`       — GET `/web/health` (Odoo 17+ liveness)
4. `web_login`        — GET `/web/login` HTML markers
5. `root_headers`     — HEAD `/` (server: nginx / Odoo.sh / cloudflare)
6. `jsonrpc_version`  — POST `/jsonrpc` common.version
7. `json2_unauth`     — POST `/json/2/res.users/context_get` unauth
                        (401 "Invalid apikey" → JSON/2 live → v19+)
8. `dns_cloudflare`   — A lookup + CF IPv4 range check

Aggregator votes over the probes, records conflicts, and labels
confidence as high / medium / low. Tested live against four URLs:

| URL | hosting | api | major | confidence | probes_ok |
|---|---|---|---|---|---|
| odoo.eventus.tools | behind_waf | json2 | 19 | high | 8/8 |
| demo-video.odoo.com | online | json2 | 19 | high | 8/8 |
| pantalytics.odoo.com | sh | json2 | 19 | high | 8/8 |
| nonexistent | unknown | unknown | — | low | 0/8 |

~1.3s total elapsed (max-of-8 in parallel).

The admin app (pantalytics/odoo-mcp-pro-admin#38) calls `detect_odoo`
directly and persists the full evidence as JSONB. OSS standalone keeps
the legacy `version_detect.detect_api_version` shim for now.

## Test plan

- [x] `pytest tests/ -m "not integration"` — 541 passed (+17 new), 0 failures
- [x] End-to-end from laptop against `odoo.eventus.tools`:
  - `Json2Connection.connect()` returns 200 (was 403)
  - `authenticate()` with bogus key returns Odoo's `"Invalid apikey"` 401
- [x] Live shotgun test against 4 URLs — all classify correctly
- [ ] After merge + deploy: re-test with James's real API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)