### PR TITLE
fix(analytics): distinguish Online from odoo.sh in connection_error hosting

### DIFF
--- a/mcp_server_odoo/registry.py
+++ b/mcp_server_odoo/registry.py
@@ -8,7 +8,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, Optional
 
 from .access_control import AccessController
 from .config import OdooConfig
@@ -24,6 +24,21 @@ logger = logging.getLogger(__name__)
 
 # Default connection idle TTL: 30 minutes
 DEFAULT_TTL = 1800
+
+
+def _hosting_label(url: str, server_version: Optional[str]) -> str:
+    """Best-effort hosting label from the signals available at connect time.
+
+    Odoo Online and Odoo.sh both live on *.odoo.com, so the URL alone cannot
+    separate them. Only Online is reliably identifiable: its server_version
+    carries a 'saas~' prefix. The rest of the shared domain is labelled 'sh'.
+    Labels match the detection module's Hosting values.
+    """
+    if "saas~" in (server_version or ""):
+        return "online"
+    if ".odoo.com" in url.lower():
+        return "sh"
+    return "self_hosted"
 
 
 @dataclass
@@ -168,9 +183,10 @@ class ConnectionRegistry:
                 properties={
                     "type": error_type,
                     "api_version": api_version,
-                    "hosting": "odoo.sh"
-                    if ".odoo.com" in user_conn.odoo_url.lower()
-                    else "self-hosted",
+                    "hosting": _hosting_label(
+                        user_conn.odoo_url,
+                        server_version or user_conn.odoo_version,
+                    ),
                 },
             )
 

--- a/tests/test_registry_hosting_label.py
+++ b/tests/test_registry_hosting_label.py
@@ -1,0 +1,29 @@
+"""Hosting label on connection_error analytics events.
+
+Odoo Online and Odoo.sh share the *.odoo.com domain, so the label must use
+the server_version 'saas~' marker to separate them (see _hosting_label).
+"""
+
+from mcp_server_odoo.registry import _hosting_label
+
+
+class TestHostingLabel:
+    def test_saas_version_is_online(self):
+        assert _hosting_label("https://acme.odoo.com", "saas~19.3+e") == "online"
+
+    def test_saas_version_wins_over_custom_domain(self):
+        # Online instances can sit behind a custom domain; the version marker
+        # is the reliable signal, not the URL.
+        assert _hosting_label("https://erp.acme.com", "saas~19.2+e") == "online"
+
+    def test_odoo_com_without_saas_is_sh(self):
+        assert _hosting_label("https://acme.odoo.com", "19.0+e") == "sh"
+
+    def test_odoo_com_case_insensitive(self):
+        assert _hosting_label("https://Acme.Odoo.COM", None) == "sh"
+
+    def test_custom_domain_is_self_hosted(self):
+        assert _hosting_label("https://erp.acme.com", "18.0+e") == "self_hosted"
+
+    def test_none_version_custom_domain(self):
+        assert _hosting_label("https://erp.acme.com", None) == "self_hosted"


### PR DESCRIPTION
## Why

PostHog analysis of the auth_failed spike (2026-06-08/10) was misleading: the `connection_error` event labels every `*.odoo.com` URL as `odoo.sh`, conflating Odoo Online with Odoo.sh. Five of the affected users turned out to be on Odoo Online (saas~19.x), where API access is plan-gated - a distinction the event hid.

## What

- `_hosting_label()` helper in `registry.py`: `saas~` in server_version -> `online`, else `*.odoo.com` -> `sh`, else `self_hosted`. Falls back to the version stored at setup when live detection returned nothing. Labels match the detection module's `Hosting` values (the URL-detect event already emits these, so the two events now agree).
- Unit tests for the helper, including the Online-behind-custom-domain case.

## Note for dashboard filters

Historical events keep the old labels (`odoo.sh` / `self-hosted`); any PostHog insight filtering on those needs updating once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)