### PR TITLE
fix(post_message): never report a successful post as a failure

### DIFF
--- a/mcp_server_odoo/schemas.py
+++ b/mcp_server_odoo/schemas.py
@@ -181,6 +181,14 @@ class PostMessageResult(BaseModel):
         description="x_microsoft_message_id when pan_outlook_pro is installed and the send went via Graph",
     )
     record_url: str = Field(description="Direct URL to the record in Odoo")
+    degraded_details: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Detail sections that could not be read back after a successful post "
+            "(e.g. 'message details', 'notification status'). The message itself "
+            "was posted; only the follow-up enrichment failed."
+        ),
+    )
     message: str = Field(description="Human-readable summary")
 
 

--- a/mcp_server_odoo/tools.py
+++ b/mcp_server_odoo/tools.py
@@ -1974,57 +1974,93 @@ class OdooToolHandler:
                 if not isinstance(message_id, int):
                     raise ValidationError(f"Unexpected message_post return: {raw!r}")
 
-                # Read message back for subtype/attachment summary
-                msg_fields = ["subtype_id", "attachment_ids"]
-                # x_microsoft_message_id only exists when pan_outlook_pro is installed
-                outlook_field = "x_microsoft_message_id"
-                try:
-                    available = connection.fields_get(
-                        "mail.message", [outlook_field], allfields=False
-                    )
-                except TypeError:
-                    available = connection.fields_get("mail.message", [outlook_field])
-                except Exception:
-                    available = {}
-                if outlook_field in (available or {}):
-                    msg_fields.append(outlook_field)
+                # From here on the message exists in Odoo. The reads below only
+                # enrich the response; they must never turn a successful post into
+                # a reported failure. Some Odoo builds cannot serialise
+                # mail.message-related responses over RPC (e.g. server-side
+                # "TypeError: cannot marshal <class 'File'> objects" from Odoo's
+                # OdooMarshaller, seen on Odoo Online), so each follow-up read is
+                # tolerated individually: log the underlying error loudly and
+                # degrade the detail instead of raising.
+                degraded: List[str] = []
 
-                msg_rows = connection.read("mail.message", [message_id], msg_fields)
-                msg = msg_rows[0] if msg_rows else {}
-                subtype_pair = msg.get("subtype_id")
-                subtype_name = (
-                    subtype_pair[1]
-                    if isinstance(subtype_pair, list) and len(subtype_pair) > 1
-                    else None
-                )
-                attachments = msg.get("attachment_ids") or []
-                outlook_msg_id = msg.get(outlook_field) if outlook_field in msg_fields else None
-                if outlook_msg_id is False:
-                    outlook_msg_id = None
+                # Read message back for subtype/attachment summary
+                subtype_name: Optional[str] = None
+                attachments: List[Any] = []
+                outlook_msg_id: Optional[Any] = None
+                try:
+                    msg_fields = ["subtype_id", "attachment_ids"]
+                    # x_microsoft_message_id only exists when pan_outlook_pro is installed
+                    outlook_field = "x_microsoft_message_id"
+                    try:
+                        available = connection.fields_get(
+                            "mail.message", [outlook_field], allfields=False
+                        )
+                    except TypeError:
+                        available = connection.fields_get("mail.message", [outlook_field])
+                    except Exception:
+                        available = {}
+                    if outlook_field in (available or {}):
+                        msg_fields.append(outlook_field)
+
+                    msg_rows = connection.read("mail.message", [message_id], msg_fields)
+                    msg = msg_rows[0] if msg_rows else {}
+                    subtype_pair = msg.get("subtype_id")
+                    subtype_name = (
+                        subtype_pair[1]
+                        if isinstance(subtype_pair, list) and len(subtype_pair) > 1
+                        else None
+                    )
+                    attachments = msg.get("attachment_ids") or []
+                    outlook_msg_id = msg.get(outlook_field) if outlook_field in msg_fields else None
+                    if outlook_msg_id is False:
+                        outlook_msg_id = None
+                except Exception:
+                    logger.error(
+                        "post_message: mail.message %s was posted to %s:%s but reading "
+                        "the message back failed; returning success with degraded detail",
+                        message_id,
+                        model,
+                        record_id,
+                        exc_info=True,
+                    )
+                    degraded.append("message details")
 
                 # Read notifications fan-out
-                notif_rows = connection.search_read(
-                    "mail.notification",
-                    [("mail_message_id", "=", message_id)],
-                    [
-                        "res_partner_id",
-                        "notification_type",
-                        "notification_status",
-                        "failure_reason",
-                    ],
-                )
                 notifications: List[Dict[str, Any]] = []
-                for n in notif_rows:
-                    p = n.get("res_partner_id") or [None, ""]
-                    notifications.append(
-                        {
-                            "partner_id": p[0] if isinstance(p, list) else None,
-                            "partner_name": p[1] if isinstance(p, list) and len(p) > 1 else "",
-                            "type": n.get("notification_type") or "",
-                            "status": n.get("notification_status") or "",
-                            "failure_reason": n.get("failure_reason") or None,
-                        }
+                try:
+                    notif_rows = connection.search_read(
+                        "mail.notification",
+                        [("mail_message_id", "=", message_id)],
+                        [
+                            "res_partner_id",
+                            "notification_type",
+                            "notification_status",
+                            "failure_reason",
+                        ],
                     )
+                    for n in notif_rows:
+                        p = n.get("res_partner_id") or [None, ""]
+                        notifications.append(
+                            {
+                                "partner_id": p[0] if isinstance(p, list) else None,
+                                "partner_name": p[1] if isinstance(p, list) and len(p) > 1 else "",
+                                "type": n.get("notification_type") or "",
+                                "status": n.get("notification_status") or "",
+                                "failure_reason": n.get("failure_reason") or None,
+                            }
+                        )
+                except Exception:
+                    logger.error(
+                        "post_message: mail.message %s was posted to %s:%s but reading "
+                        "the notification fan-out failed; returning success with "
+                        "degraded detail",
+                        message_id,
+                        model,
+                        record_id,
+                        exc_info=True,
+                    )
+                    degraded.append("notification status")
 
                 base_url = (
                     getattr(connection, "_base_url", None)
@@ -2041,6 +2077,11 @@ class OdooToolHandler:
                     )
                 if outlook_msg_id:
                     summary_bits.append("sent via Microsoft Graph")
+                if degraded:
+                    summary_bits.append(
+                        "the message was posted, but Odoo could not return "
+                        f"{' and '.join(degraded)} (see server logs)"
+                    )
 
                 return {
                     "success": True,
@@ -2050,6 +2091,7 @@ class OdooToolHandler:
                     "notifications": notifications,
                     "outlook_pro_message_id": outlook_msg_id,
                     "record_url": record_url,
+                    "degraded_details": degraded,
                     "message": "; ".join(summary_bits),
                 }
 

--- a/tests/test_post_message.py
+++ b/tests/test_post_message.py
@@ -212,6 +212,149 @@ class TestPostMessageUnit:
         assert result["notifications"][0]["status"] == "sent"
         assert result["notifications"][1]["partner_name"] == "Bob"
         assert result["notifications"][1]["type"] == "inbox"
+        assert result["degraded_details"] == []
+
+
+class TestPostMessageDegradedDetail:
+    """A successful post must never be reported as a failure (ticket 61).
+
+    Some Odoo builds (seen on Odoo Online, helpdesk.ticket and discuss.channel)
+    cannot serialise mail.message-related objects in the RPC response of the
+    follow-up reads: the server raises "TypeError: cannot marshal <class 'File'>
+    objects" in OdooMarshaller.dumps() AFTER the message already landed in the
+    chatter. The tool must then return success with degraded detail, not raise.
+    """
+
+    # The fault our XML-RPC client receives when Odoo's OdooMarshaller chokes
+    # on the response of a follow-up read (ticket 61, yape.odoo.com).
+    MARSHAL_FAULT = Exception(
+        '<Fault 1: "Traceback (most recent call last):\\n...\\n'
+        "TypeError: cannot marshal <class 'File'> objects\\n\""
+        " in OdooMarshaller.dumps()>"
+    )
+
+    @pytest.fixture
+    def mock_app(self):
+        app = Mock()
+        app.tool = Mock(side_effect=lambda **kwargs: lambda func: func)
+        return app
+
+    @pytest.fixture
+    def mock_connection(self):
+        conn = Mock()
+        conn.is_authenticated = True
+        conn._base_url = "http://localhost:8169"
+        return conn
+
+    @pytest.fixture
+    def handler(self, mock_app, mock_connection):
+        controller = Mock()
+        controller.validate_model_access = Mock()
+        config = Mock()
+        config.url = "http://localhost:8169"
+        return OdooToolHandler(mock_app, mock_connection, controller, config)
+
+    @pytest.mark.asyncio
+    async def test_message_readback_failure_degrades(self, handler, mock_connection):
+        """mail.message readback fails to serialise -> success with degraded detail."""
+        mock_connection.read.side_effect = [
+            [{"id": 7}],  # existence check
+            self.MARSHAL_FAULT,  # message readback blows up server-side
+        ]
+        mock_connection.fields_get.return_value = {}
+        mock_connection.call_method.return_value = 42
+        mock_connection.search_read.return_value = []
+
+        result = await handler._handle_post_message_tool(
+            model="helpdesk.ticket", record_id=7, body="<p>hi</p>"
+        )
+
+        assert result["success"] is True
+        assert result["message_id"] == 42
+        assert result["subtype"] is None
+        assert result["attachment_count"] == 0
+        assert result["outlook_pro_message_id"] is None
+        assert result["degraded_details"] == ["message details"]
+        assert "message details" in result["message"]
+        # The notification read still ran and succeeded
+        assert result["notifications"] == []
+
+    @pytest.mark.asyncio
+    async def test_notification_read_failure_degrades(self, handler, mock_connection):
+        """mail.notification fan-out read fails -> success, notifications empty."""
+        mock_connection.read.side_effect = [
+            [{"id": 7}],
+            [{"subtype_id": [1, "Discussions"], "attachment_ids": []}],
+        ]
+        mock_connection.fields_get.return_value = {}
+        mock_connection.call_method.return_value = 42
+        mock_connection.search_read.side_effect = self.MARSHAL_FAULT
+
+        result = await handler._handle_post_message_tool(
+            model="discuss.channel", record_id=7, body="<p>hi</p>"
+        )
+
+        assert result["success"] is True
+        assert result["message_id"] == 42
+        assert result["subtype"] == "Discussions"
+        assert result["notifications"] == []
+        assert result["degraded_details"] == ["notification status"]
+        assert "notification status" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_all_followup_reads_fail_still_success(self, handler, mock_connection):
+        """Both follow-up reads fail -> still success, both sections degraded."""
+        mock_connection.read.side_effect = [
+            [{"id": 7}],
+            self.MARSHAL_FAULT,
+        ]
+        mock_connection.fields_get.return_value = {}
+        mock_connection.call_method.return_value = 42
+        mock_connection.search_read.side_effect = self.MARSHAL_FAULT
+
+        result = await handler._handle_post_message_tool(
+            model="helpdesk.ticket", record_id=7, body="<p>hi</p>"
+        )
+
+        assert result["success"] is True
+        assert result["message_id"] == 42
+        assert result["degraded_details"] == ["message details", "notification status"]
+        assert "posted mail.message 42" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_followup_failure_logged_loudly(self, handler, mock_connection, caplog):
+        """The underlying exception is logged with a traceback, not swallowed."""
+        import logging
+
+        mock_connection.read.side_effect = [
+            [{"id": 7}],
+            self.MARSHAL_FAULT,
+        ]
+        mock_connection.fields_get.return_value = {}
+        mock_connection.call_method.return_value = 42
+        mock_connection.search_read.return_value = []
+
+        with caplog.at_level(logging.ERROR, logger="mcp_server_odoo.tools"):
+            result = await handler._handle_post_message_tool(
+                model="helpdesk.ticket", record_id=7, body="<p>hi</p>"
+            )
+
+        assert result["success"] is True
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert any("posted to helpdesk.ticket:7" in r.getMessage() for r in error_records)
+        assert any(r.exc_info and "cannot marshal" in str(r.exc_info[1]) for r in error_records)
+
+    @pytest.mark.asyncio
+    async def test_post_itself_failing_still_raises(self, handler, mock_connection):
+        """Tolerance only applies AFTER the post; a failing message_post still errors."""
+        mock_connection.read.return_value = [{"id": 7}]
+        mock_connection.fields_get.return_value = {}
+        mock_connection.call_method.side_effect = Exception("boom")
+
+        with pytest.raises(ValidationError, match="Failed to post message"):
+            await handler._handle_post_message_tool(
+                model="res.partner", record_id=7, body="<p>hi</p>"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Bug (ticket 61, MCP Pro 1.5.1)

`post_message` posts the chatter message successfully (it visibly lands in Odoo), then reports a failure to the client:

```
TypeError: cannot marshal <class 'File'> objects
```

raised inside Odoo's server-side `OdooMarshaller.dumps()`. Seen on Odoo Online, on `helpdesk.ticket` and `discuss.channel`, with both `mail.mt_comment` and `mail.mt_note`, plain text and HTML, with and without subject. Read operations were unaffected.

## Root cause

The fault text is Odoo's **server-side** XML-RPC marshaller failing to serialise a response to us. Because the xmlrpc controller catches the marshal error and returns a Fault as a normal response, the transaction still commits: the message lands, the client gets an error.

Two findings from the Odoo source line this up:

- Since saas-18.2 (so all of Odoo Online and 19.0+), `message_post` lost its `@api.returns('mail.message')` decorator. `call_kw` only has a top-level `isinstance(result, BaseModel) -> result.ids` net; anything non-marshallable **nested** in a dict/list result (as in `read`/`search_read` rows) goes straight to `OdooMarshaller.dumps()`.
- No `class File` exists anywhere in community Odoo (verified against a saas-19.2 checkout), so the object is injected by enterprise/Online-side code into one of our **follow-up enrichment reads** after the post: the `mail.message` readback (subtype/attachments/outlook id) or the `mail.notification` fan-out query.

Prod log evidence is gone (containers were recreated at the last deploy, wiping `docker logs`), so the exact enterprise field could not be pinned down. The fix does not depend on it.

## Fix

Principle: **a successful post must never be reported as a failure.** Once `message_post` has returned a message id, the remaining reads only enrich the response:

- The message readback (incl. the `x_microsoft_message_id` probe) and the notification fan-out read are each tolerated individually.
- On failure the underlying exception is logged loudly (`logger.error` with full traceback, message/model/record ids), the section is listed in a new `degraded_details` response field, and the summary gets a human-readable note.
- The tool returns `success: true` with whatever detail is available. No silent fallback: every degraded section is visible in both the response and the server logs.
- A failing `message_post` itself still raises exactly as before.

## Tests

- 5 new unit tests simulating the marshal fault on each follow-up read (message readback, notification read, both, loud-logging assertion, and post-itself-still-raises).
- `tests/test_post_message.py`: 13 unit tests pass; the 4 integration tests pass against the local docker Odoo 18 stack (after installing `mail` into the test DB).
- Full suite on a clean checkout: 553 passed; the 11 failures + 7 errors are environment-dependent integration tests and are byte-identical with and without this change.
- `ruff check` and `ruff format --check` pass repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)