### PR TITLE
feat: add create_fastmcp_app factory (admin extension contract)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,15 @@ The SaaS features (multi-tenant, OAuth, admin UI, billing) live in the private
 - Dev overlay: admin's `local-dev.sh` symlinks admin code into `mcp_server_odoo/admin/`.
   These symlinks are `.gitignore`'d (or untracked) and should not be committed.
 
+**Admin extension contract** (admin subclasses/imports these — rename only in
+coordination with the admin repo):
+- `server.create_fastmcp_app(*, auth=None, token_verifier=None)` — single source
+  of truth for FastMCP construction; admin's multi-tenant entry point uses it
+- `tools.OdooToolHandler._get_user_context` / `._track_usage` — hook methods the
+  admin package overrides for per-user connection resolution and usage tracking
+- `tools._current_sub` — contextvar carrying the authenticated subject
+- `resources.OdooResourceHandler._get_user_context` — same hook for resources
+
 ## JSON/2 API key points
 
 - Endpoint: `POST /json/2/{model}/{method}`

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -71,6 +71,27 @@ _DCR_STATIC_HOSTS = frozenset(
 _DCR_MAX_URIS_PER_REQUEST = 5
 
 
+def create_fastmcp_app(*, auth=None, token_verifier=None) -> FastMCP:
+    """Create the FastMCP app with the canonical server settings.
+
+    Single source of truth for FastMCP construction — used by OdooMCPServer
+    and by the private admin package's multi-tenant entry point. stateless_http
+    so any replica can serve any request (blue/green deploys don't drop client
+    connections with "No transport found for sessionId").
+    """
+    app = FastMCP(
+        name="odoo-mcp-server",
+        instructions=SERVER_INSTRUCTIONS,
+        auth=auth,
+        token_verifier=token_verifier,
+        stateless_http=True,
+        json_response=True,
+    )
+    # Skill resources — markdown workflow guides, no DB connection needed
+    register_skills(app)
+    return app
+
+
 def _resolve_static_client_id(host: str) -> str:
     """Map a static-redirect host to its OIDC client_id from env.
 
@@ -246,18 +267,7 @@ class OdooMCPServer:
         # Configure OAuth if environment variables are set
         auth_settings, token_verifier = self._build_oauth_settings()
 
-        # Create FastMCP instance with server metadata.
-        # stateless_http=True so any replica can serve any request — sessions
-        # don't pin to a single container, so blue/green deploys don't drop
-        # client connections with "No transport found for sessionId".
-        self.app = FastMCP(
-            name="odoo-mcp-server",
-            instructions=SERVER_INSTRUCTIONS,
-            auth=auth_settings,
-            token_verifier=token_verifier,
-            stateless_http=True,
-            json_response=True,
-        )
+        self.app = create_fastmcp_app(auth=auth_settings, token_verifier=token_verifier)
 
         if auth_settings:
             logger.info(f"OAuth enabled (issuer: {auth_settings.issuer_url})")


### PR DESCRIPTION
Phase A of the open-core split (Option B).

- `create_fastmcp_app(*, auth=None, token_verifier=None)`: single source of truth for FastMCP construction; the admin repo's upcoming multi-tenant entry point composes this instead of public's `run_http` multi-tenant branch.
- CLAUDE.md: documents the admin extension contract (`create_fastmcp_app`, `_get_user_context`, `_track_usage`, `_current_sub`).

Additive only — no removals. After merge, public main gets tagged `v1.7.0` for the admin pin. (Replaces #55, which auto-closed when its stacked base #52 was squash-merged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)