### PR TITLE
fix(oauth): advertise scope in DCR response for Copilot Studio

### DIFF
--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -82,6 +82,17 @@ _DCR_DYNAMIC_ENV_PREFIXES = {
 }
 _DCR_MAX_URIS_PER_REQUEST = 5
 
+# OAuth scopes this server advertises everywhere a scope list is served:
+# the protected-resource and authorization-server metadata, and the DCR
+# registration response. Single source so the three never drift. `openid`
+# is the only hard requirement (see _build_oauth_settings.required_scopes);
+# the rest enrich the token (email/profile in introspection, offline_access
+# for refresh tokens). Some clients (Microsoft Copilot Studio) read the
+# `scope` field from the DCR response to build their authorize request and
+# send no scope at all without it — Zitadel then rejects with
+# "The scope of your request is missing".
+_OAUTH_SCOPES = ["openid", "profile", "email", "offline_access"]
+
 
 def create_fastmcp_app(*, auth=None, token_verifier=None) -> FastMCP:
     """Create the FastMCP app with the canonical server settings.
@@ -345,12 +356,7 @@ class OdooMCPServer:
                 {
                     "resource": resource_server_url,
                     "authorization_servers": [server_root],
-                    "scopes_supported": [
-                        "openid",
-                        "profile",
-                        "email",
-                        "offline_access",
-                    ],
+                    "scopes_supported": _OAUTH_SCOPES,
                     "bearer_methods_supported": ["header"],
                 }
             )
@@ -366,12 +372,7 @@ class OdooMCPServer:
                     "authorization_endpoint": f"{zitadel}/oauth/v2/authorize",
                     "token_endpoint": f"{zitadel}/oauth/v2/token",
                     "registration_endpoint": f"{server_root}/register",
-                    "scopes_supported": [
-                        "openid",
-                        "profile",
-                        "email",
-                        "offline_access",
-                    ],
+                    "scopes_supported": _OAUTH_SCOPES,
                     "response_types_supported": ["code"],
                     "grant_types_supported": [
                         "authorization_code",
@@ -474,6 +475,9 @@ class OdooMCPServer:
                 "redirect_uris": raw_uris,
                 "grant_types": ["authorization_code", "refresh_token"],
                 "response_types": ["code"],
+                # Advertise the scopes so clients that build their authorize
+                # request from the DCR response (Copilot Studio) send them.
+                "scope": " ".join(_OAUTH_SCOPES),
             }
 
             if all_static:

--- a/tests/test_oauth_dcr.py
+++ b/tests/test_oauth_dcr.py
@@ -15,6 +15,7 @@ from mcp_server_odoo.server import (
     _DCR_ALLOWED_HOSTS,
     _DCR_DYNAMIC_ENV_PREFIXES,
     _DCR_STATIC_HOSTS,
+    _OAUTH_SCOPES,
     _append_redirect_uris_to_dcr_app,
     _DCRUpdateError,
     _resolve_dcr_env,
@@ -104,6 +105,25 @@ class TestDCRAllowlist:
         # The /register dynamic path 500s on a host that is allowed but
         # neither static nor mapped to a dynamic app; pin full coverage.
         assert _DCR_ALLOWED_HOSTS == _DCR_STATIC_HOSTS | set(_DCR_DYNAMIC_ENV_PREFIXES)
+
+
+class TestOAuthScopes:
+    """The advertised scope list feeds PRM, ASM and the DCR response."""
+
+    def test_includes_openid(self):
+        # openid is the only scope _build_oauth_settings requires of every
+        # token; advertising less than what we require would be incoherent.
+        assert "openid" in _OAUTH_SCOPES
+
+    def test_includes_offline_access_for_refresh(self):
+        # Without offline_access Zitadel issues no refresh token, so the
+        # connection would silently die when the access token expires.
+        assert "offline_access" in _OAUTH_SCOPES
+
+    def test_is_space_joinable_for_dcr_scope_field(self):
+        # The DCR response serves " ".join(_OAUTH_SCOPES) as the `scope`
+        # string; a stray empty/space entry would corrupt it.
+        assert all(s and " " not in s for s in _OAUTH_SCOPES)
 
 
 class TestResolveStaticClientId:


### PR DESCRIPTION
## What

After #57 fixed Copilot Studio's DCR registration, the next step (the Zitadel authorize redirect) failed:

```
invalid_request: The scope of your request is missing. Please ensure some scopes are requested.
```

Copilot Studio builds its authorize request from the `scope` field of the RFC 7591 registration response. We never returned one, so it requested no scopes and Zitadel rejected it. (Claude/ChatGPT derive scopes from the AS metadata instead, so they were unaffected.)

## Change

- New `_OAUTH_SCOPES` constant = `openid profile email offline_access` (what we already advertised, now in one place).
- Served from protected-resource metadata, authorization-server metadata, and the DCR response's `scope` field. Single source so they can't drift.
- No change to `required_scopes` (still `openid` only).

## Tests

38 passed. New `TestOAuthScopes` pins openid + offline_access presence and that the list is safely space-joinable for the DCR `scope` string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)