### PR TITLE
chore: bump version to 2.1.1

### DIFF
--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -34,7 +34,7 @@ from .version_detect import detect_api_version
 logger = get_logger(__name__)
 
 # Server version — keep in sync with pyproject.toml
-SERVER_VERSION = "2.0.0"
+SERVER_VERSION = "2.1.1"
 GIT_COMMIT = os.environ.get("GIT_COMMIT", "unknown")
 _BUILD_ORIGIN = "pnl-mcp-7f3a"  # Pantalytics provenance tag
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-server-odoo"
-version = "2.0.0"
+version = "2.1.1"
 description = "AI connector for Odoo ERP -- connect Claude, ChatGPT, and other AI tools to Odoo via MCP (Model Context Protocol)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Keep the public package version in sync with the admin panel (mcp-server-odoo-admin 2.1.1).

- `pyproject.toml` version 2.0.0 -> 2.1.1
- `SERVER_VERSION` 2.0.0 -> 2.1.1 (the value the admin sidebar reads for the "mcp" version)

No behavior change; version markers only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)