### PR TITLE
feat(server_info): surface why the connection is not established

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 - **Connection survives server deploys**: streamable-HTTP transport now runs in stateless mode (`stateless_http=True`, `json_response=True`). Previously the server kept session state in-memory per replica, so blue/green deploys dropped `Mcp-Session-Id` mappings and Claude/ChatGPT clients reported "connection lost". Stateless requests are independent, so any replica can serve any request and rolling deploys are invisible to clients. No server-initiated notifications were in use, so no feature loss.
 - **XML-RPC username resolution**: `registry.get_connection` now reads `user_conn.odoo_login` (when set) and falls back to `user_conn.email`. Odoo authenticates against `res.users.login`, which can differ from the user's email (e.g. `login="admin"`); the previous behavior locked everyone to the sign-up email.
 - **`server_info` observability**: `_current_sub` is now set before the registry/rate-limit calls in `_get_user_context`, so when those raise and a tool catches the exception (notably `server_info`), usage tracking still attributes the event to the correct user instead of silently no-op'ing as `"stdio"`.
+- **`server_info` reports why it is not connected**: when the Odoo connection cannot be established (for example an invalid API key or an unreachable server), `server_info` now returns the reason in a new `error` field instead of only `connected: false`. AI clients can relay it so the user knows what to fix. `error` is `null` when connected.
 
 ## [1.8.0] - 2026-06-11
 

--- a/mcp_server_odoo/schemas.py
+++ b/mcp_server_odoo/schemas.py
@@ -277,6 +277,10 @@ class ServerInfoResult(BaseModel):
         description="Active Odoo database name. None on JSON/2 single-tenant where the API key resolves it server-side.",
     )
     connected: bool = Field(description="Whether the server is connected to Odoo")
+    error: Optional[str] = Field(
+        default=None,
+        description="Why the connection is not established, when connected is false (e.g. an invalid API key or an unreachable server). None when connected. Relay this to the user so they can fix it.",
+    )
     runtime_id: str = Field(description="Server runtime identifier")
     companies: List[Dict[str, Any]] = Field(
         default_factory=list,

--- a/mcp_server_odoo/tools/introspection.py
+++ b/mcp_server_odoo/tools/introspection.py
@@ -79,6 +79,7 @@ class IntrospectionToolsMixin:
             """
             from ..server import _BUILD_ORIGIN, GIT_COMMIT, SERVER_VERSION
 
+            error = None
             try:
                 connection, _ac, _sub = await self._get_user_context()
                 is_connected = (
@@ -94,11 +95,17 @@ class IntrospectionToolsMixin:
                     self.config.url if self.config else "multi-tenant"
                 )
                 database = getattr(connection, "database", None)
-            except Exception:
+            except Exception as e:
+                # Surface WHY we are not connected so the AI client can tell the
+                # user (e.g. "your API key was refused" or "server unreachable")
+                # instead of a bare "not connected". Sanitized to keep internals
+                # out of the message; the connection resolver already phrases its
+                # errors for end users.
                 is_connected = False
                 api_version = self.config.api_version if self.config else "unknown"
                 odoo_url = "not connected"
                 database = None
+                error = ErrorSanitizer.sanitize_message(str(e))
 
             # Fetch companies for context (helps with multi-company setups)
             companies = []
@@ -118,6 +125,7 @@ class IntrospectionToolsMixin:
                 odoo_url=odoo_url,
                 database=database,
                 connected=is_connected,
+                error=error,
                 runtime_id=_BUILD_ORIGIN,
                 companies=companies,
             )

--- a/tests/test_server_info.py
+++ b/tests/test_server_info.py
@@ -1,0 +1,55 @@
+"""Tests for the server_info tool's connection-status reporting.
+
+Shared tool fixtures live in tests/helpers/tool_fixtures.py.
+"""
+
+import pytest
+
+from tests.helpers.tool_fixtures import (
+    handler,
+    mock_access_controller,
+    mock_app,
+    mock_connection,
+    valid_config,
+)
+
+# Re-export shared fixtures so pytest can resolve them in this module
+__all__ = [
+    "handler",
+    "mock_access_controller",
+    "mock_app",
+    "mock_connection",
+    "valid_config",
+]
+
+
+class TestServerInfo:
+    """server_info should explain WHY it is not connected, not just that it isn't."""
+
+    @pytest.mark.asyncio
+    async def test_surfaces_connection_error(self, handler, mock_app):
+        """When the connection cannot be resolved, the failure reason is
+        reported in `error` (alongside connected=False) so the AI client can
+        relay it to the user instead of a bare "not connected"."""
+
+        async def _raise():
+            raise Exception("Authentication failed: Invalid apikey")
+
+        handler._get_user_context = _raise
+
+        result = await mock_app._tools["server_info"]()
+
+        assert result.connected is False
+        assert result.error is not None
+        assert "Invalid apikey" in result.error
+
+    @pytest.mark.asyncio
+    async def test_no_error_when_connected(self, handler, mock_connection, mock_app):
+        """A healthy connection reports error=None."""
+        mock_connection.database = "test_db"
+        mock_connection.search_read.return_value = []
+
+        result = await mock_app._tools["server_info"]()
+
+        assert result.connected is True
+        assert result.error is None


### PR DESCRIPTION
## What

`server_info` caught any connection-resolution failure in a bare `except` and reported `connected: false` with no reason. So when a member's Odoo connection breaks (invalid/deleted API key, unreachable server, unresolved database), the AI client only saw "not connected" and could not tell the user what to fix. The actual reason was thrown away.

This is the client-side counterpart to the connections-page health work in the admin repo (PR #102 there): the admin page now shows "Sign-in failed" etc., but the AI client itself was still blind.

## Change

- `ServerInfoResult` gains an optional `error` field (null when connected).
- On a resolution failure, `server_info` populates `error` with the sanitized failure reason (the resolver already phrases these for end users, e.g. "Authentication failed: Invalid apikey" or "Cannot reach your Odoo server at ...").
- All other fields keep their meaning; `connected` still reflects status.

## Tests

- `tests/test_server_info.py`: failed path (error surfaced, `connected=false`) and healthy path (`error=None`).
- Existing tool unit tests still pass; ruff lint + format clean.

## Note

Real-world trigger: a customer (beanforge, Odoo 19 / JSON2) deleted their API key; the admin health pill correctly showed "Sign-in failed", but `server_info` from the AI client still said only "not connected". This closes that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)