### PR TITLE
chore: release 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 - **Connection survives server deploys**: streamable-HTTP transport now runs in stateless mode (`stateless_http=True`, `json_response=True`). Previously the server kept session state in-memory per replica, so blue/green deploys dropped `Mcp-Session-Id` mappings and Claude/ChatGPT clients reported "connection lost". Stateless requests are independent, so any replica can serve any request and rolling deploys are invisible to clients. No server-initiated notifications were in use, so no feature loss.
 - **XML-RPC username resolution**: `registry.get_connection` now reads `user_conn.odoo_login` (when set) and falls back to `user_conn.email`. Odoo authenticates against `res.users.login`, which can differ from the user's email (e.g. `login="admin"`); the previous behavior locked everyone to the sign-up email.
 - **`server_info` observability**: `_current_sub` is now set before the registry/rate-limit calls in `_get_user_context`, so when those raise and a tool catches the exception (notably `server_info`), usage tracking still attributes the event to the correct user instead of silently no-op'ing as `"stdio"`.
+
+## [2.1.2] - 2026-06-17
+
+### Fixed
 - **`server_info` reports why it is not connected**: when the Odoo connection cannot be established (for example an invalid API key or an unreachable server), `server_info` now returns the reason in a new `error` field instead of only `connected: false`. AI clients can relay it so the user knows what to fix. `error` is `null` when connected.
 
 ## [1.8.0] - 2026-06-11

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -34,7 +34,7 @@ from .version_detect import detect_api_version
 logger = get_logger(__name__)
 
 # Server version — keep in sync with pyproject.toml
-SERVER_VERSION = "2.1.1"
+SERVER_VERSION = "2.1.2"
 GIT_COMMIT = os.environ.get("GIT_COMMIT", "unknown")
 _BUILD_ORIGIN = "pnl-mcp-7f3a"  # Pantalytics provenance tag
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-server-odoo"
-version = "2.1.1"
+version = "2.1.2"
 description = "AI connector for Odoo ERP -- connect Claude, ChatGPT, and other AI tools to Odoo via MCP (Model Context Protocol)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Cuts **2.1.2**. Only change since v2.1.1 is the `server_info` error-surfacing fix (PR #65): when a connection cannot be established, `server_info` returns the reason in a new `error` field instead of a bare `connected: false`, so AI clients can tell the user what to fix.

- bump `pyproject.toml` and `SERVER_VERSION` to 2.1.2
- add `[2.1.2]` to CHANGELOG

After merge: tag `v2.1.2` on the merge commit, then bump the pin in `odoo-mcp-pro-admin` to `@v2.1.2` and deploy.

Note: the CHANGELOG `[Unreleased]` section still lists items that already shipped in 2.1.1 (pre-existing drift, left untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)