### PR TITLE
fix(delete_record): handle records with no name (name=False)

### DIFF
--- a/mcp_server_odoo/tools/crud.py
+++ b/mcp_server_odoo/tools/crud.py
@@ -272,10 +272,13 @@ class CrudToolsMixin:
                 if not existing:
                     raise NotFoundError(f"Record not found: {model} with ID {record_id}")
 
-                # Store some info about the record before deletion
-                record_name = existing[0].get(
-                    "name", existing[0].get("display_name", f"ID {record_id}")
-                )
+                # Store some info about the record before deletion. Odoo returns
+                # `False` (not a missing key) for an empty char field, so a plain
+                # .get("name", default) yields False for unnamed records (e.g. a
+                # draft credit note). Fall through on any falsy value so
+                # deleted_name stays a string.
+                record = existing[0]
+                record_name = record.get("name") or record.get("display_name") or f"ID {record_id}"
 
                 # Delete the record
                 success = connection.unlink(model, [record_id])

--- a/tests/test_write_tools.py
+++ b/tests/test_write_tools.py
@@ -173,6 +173,33 @@ class TestWriteTools:
         mock_connection.unlink.assert_called_once_with(model, [record_id])
 
     @pytest.mark.asyncio
+    async def test_delete_record_unnamed_record(self, tool_handler, mock_connection):
+        """Odoo returns name=False for an unnamed record (e.g. a draft credit
+        note). deleted_name must still be a string: fall back to display_name,
+        then to an ID label, never propagate False."""
+        record_id = 263
+        mock_connection.read.return_value = [
+            {"id": record_id, "name": False, "display_name": "Conceptfactuur"}
+        ]
+        mock_connection.unlink.return_value = True
+
+        result = await tool_handler._handle_delete_record_tool("account.move", record_id)
+
+        assert result["success"] is True
+        assert result["deleted_name"] == "Conceptfactuur"
+
+    @pytest.mark.asyncio
+    async def test_delete_record_no_name_at_all(self, tool_handler, mock_connection):
+        """When both name and display_name are falsy, fall back to an ID label."""
+        record_id = 264
+        mock_connection.read.return_value = [{"id": record_id, "name": False}]
+        mock_connection.unlink.return_value = True
+
+        result = await tool_handler._handle_delete_record_tool("account.move", record_id)
+
+        assert result["deleted_name"] == f"ID {record_id}"
+
+    @pytest.mark.asyncio
     async def test_delete_record_not_found(self, tool_handler, mock_connection):
         """Test delete record that doesn't exist."""
         mock_connection.read.return_value = []


### PR DESCRIPTION
delete_record crashed serializing DeleteResult when the target record had no name. Odoo returns `name: False` (not a missing key) for an empty char field - e.g. a draft credit note - so the `.get("name", default)` fallback never kicked in and `deleted_name` became `False`, which the `str` schema field rejects. The unlink itself had already succeeded, so the caller saw an error for an action that worked.

Fix: an or-chain (`name or display_name or "ID {id}"`) so any falsy value falls through. Added two regression tests (name=False with and without a display_name).

Found while testing `execute_method` against live Odoo 19 (deleting a draft credit note created by the reversal wizard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)