### PR TITLE
fix(tools): run blocking Odoo RPC off the event loop (task #759)

### DIFF
--- a/mcp_server_odoo/tools/_common.py
+++ b/mcp_server_odoo/tools/_common.py
@@ -1,10 +1,12 @@
-"""Shared module-level constants for the tools package."""
+"""Shared module-level constants and helpers for the tools package."""
 
 from __future__ import annotations
 
 import asyncio
 import contextvars
 import re
+from typing import Any, Callable, TypeVar
+from weakref import WeakKeyDictionary
 
 from ..logging_config import get_logger
 
@@ -18,3 +20,54 @@ _AVATAR_FIELD_RE = re.compile(r"^avatar_(128|256|512|1024|1920)$")
 
 # ContextVar to pass the current user's sub from _get_user_context to the wrapper
 _current_sub: contextvars.ContextVar[str] = contextvars.ContextVar("_current_sub", default="stdio")
+
+T = TypeVar("T")
+
+# Per-connection locks for off-loop RPC.
+#
+# Every blocking Odoo network call in the tool handlers runs via `run_blocking`
+# below, which hands the call to a worker thread with `asyncio.to_thread` so a
+# slow tenant no longer blocks the single event loop (and therefore every other
+# tenant). The underlying transports are NOT safe for concurrent use of the
+# SAME connection object, though: the XML-RPC backend reuses one
+# `xmlrpc.client.ServerProxy` (a single persistent socket) and the JSON/2
+# backend reuses one `curl_cffi.Session` plus an unlocked field cache. Two
+# threads hitting the same connection at once would interleave request/response
+# framing and corrupt results.
+#
+# We serialize per connection with an asyncio.Lock, NOT a global lock. The lock
+# is keyed on the connection object, so concurrent calls for the *same* user
+# (who share one cached connection) take turns, while different tenants hold
+# different connections and run in parallel. This removes head-of-line blocking
+# across tenants — the whole point of task #759 — without introducing a new
+# cross-tenant bottleneck.
+#
+# A WeakKeyDictionary lets the lock disappear when the connection is evicted/
+# garbage-collected, so nothing leaks as tenants come and go.
+_connection_locks: "WeakKeyDictionary[Any, asyncio.Lock]" = WeakKeyDictionary()
+
+
+def _lock_for(connection: Any) -> asyncio.Lock:
+    """Return the asyncio.Lock guarding a single connection's transport.
+
+    Lazily created and cached per connection object. asyncio.Lock binds to the
+    running loop on first use, which is exactly the loop the tool handlers run
+    on, so creating it here (inside an async handler) is safe.
+    """
+    lock = _connection_locks.get(connection)
+    if lock is None:
+        lock = asyncio.Lock()
+        _connection_locks[connection] = lock
+    return lock
+
+
+async def run_blocking(connection: Any, func: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
+    """Run a blocking Odoo network call off the event loop.
+
+    Wraps `asyncio.to_thread(func, *args, **kwargs)` and holds the
+    per-connection lock for the duration, so the transport is never touched by
+    two threads at once. `func` is typically a bound connection method
+    (`connection.search`, `connection.read`, `connection.call_method`, ...).
+    """
+    async with _lock_for(connection):
+        return await asyncio.to_thread(func, *args, **kwargs)

--- a/mcp_server_odoo/tools/binary.py
+++ b/mcp_server_odoo/tools/binary.py
@@ -21,6 +21,7 @@ from ._common import (
     MAX_BINARY_SIZE_BYTES,
     _current_sub,
     logger,
+    run_blocking,
 )
 
 
@@ -160,12 +161,14 @@ class BinaryToolsMixin:
                         raise ValidationError("Source produced zero bytes")
 
                     # --- Validate record exists ---
-                    existing = connection.read(model, [record_id], ["id"])
+                    existing = await run_blocking(
+                        connection, connection.read, model, [record_id], ["id"]
+                    )
                     if not existing:
                         raise NotFoundError(f"Record not found: {model} with ID {record_id}")
 
                     # --- Validate field type + auto-redirect avatar_* ---
-                    fields_info = connection.fields_get(model)
+                    fields_info = await run_blocking(connection, connection.fields_get, model)
                     if not isinstance(fields_info, dict):
                         raise ValidationError(f"Could not introspect fields of {model}")
 
@@ -214,7 +217,9 @@ class BinaryToolsMixin:
 
                     # --- Write (Odoo ORM creates/updates backing ir.attachment) ---
                     b64 = base64.b64encode(raw_bytes).decode("ascii")
-                    success = connection.write(model, [record_id], {target_field: b64})
+                    success = await run_blocking(
+                        connection, connection.write, model, [record_id], {target_field: b64}
+                    )
 
                     base_url = (
                         getattr(connection, "_base_url", None)

--- a/mcp_server_odoo/tools/bulk.py
+++ b/mcp_server_odoo/tools/bulk.py
@@ -17,7 +17,7 @@ from ..schemas import (
     BulkUpdateResult,
     ImportResult,
 )
-from ._common import MAX_BULK_SIZE, _current_sub, logger
+from ._common import MAX_BULK_SIZE, _current_sub, logger, run_blocking
 
 
 class BulkToolsMixin:
@@ -184,7 +184,9 @@ class BulkToolsMixin:
                         f"Bulk create limited to {MAX_BULK_SIZE} records, got {len(vals_list)}"
                     )
 
-                created_ids = connection.create_bulk(model, vals_list)
+                created_ids = await run_blocking(
+                    connection, connection.create_bulk, model, vals_list
+                )
 
                 return {
                     "success": True,
@@ -227,7 +229,7 @@ class BulkToolsMixin:
                         f"Bulk update limited to {MAX_BULK_SIZE} records, got {len(record_ids)}"
                     )
 
-                connection.write(model, record_ids, values)
+                await run_blocking(connection, connection.write, model, record_ids, values)
 
                 return {
                     "success": True,
@@ -267,7 +269,7 @@ class BulkToolsMixin:
                         f"Bulk delete limited to {MAX_BULK_SIZE} records, got {len(record_ids)}"
                     )
 
-                connection.unlink(model, record_ids)
+                await run_blocking(connection, connection.unlink, model, record_ids)
 
                 return {
                     "success": True,
@@ -337,7 +339,9 @@ class BulkToolsMixin:
                 # Ensure all values are strings (Odoo load() expects strings)
                 str_data = [[str(v) if v is not None else "" for v in row] for row in data]
 
-                result = connection.load_records(model, fields, str_data, safe_context)
+                result = await run_blocking(
+                    connection, connection.load_records, model, fields, str_data, safe_context
+                )
 
                 # Parse Odoo load() result
                 ids = result.get("ids", []) or []

--- a/mcp_server_odoo/tools/crud.py
+++ b/mcp_server_odoo/tools/crud.py
@@ -12,7 +12,7 @@ from ..error_sanitizer import ErrorSanitizer
 from ..logging_config import perf_logger
 from ..odoo_connection import OdooConnectionError
 from ..schemas import CreateResult, DeleteResult, UpdateResult
-from ._common import _current_sub, logger
+from ._common import _current_sub, logger, run_blocking
 
 
 class CrudToolsMixin:
@@ -122,7 +122,7 @@ class CrudToolsMixin:
                     raise ValidationError("No values provided for record creation")
 
                 # Create the record
-                record_id = connection.create(model, values)
+                record_id = await run_blocking(connection, connection.create, model, values)
 
                 # Return only essential fields to minimize context usage
                 # Users can use get_record if they need more fields
@@ -130,7 +130,9 @@ class CrudToolsMixin:
 
                 # Filter to fields that actually exist on this model
                 try:
-                    model_fields = connection.fields_get(model, ["string", "type"])
+                    model_fields = await run_blocking(
+                        connection, connection.fields_get, model, ["string", "type"]
+                    )
                     essential_fields = [f for f in essential_fields if f in model_fields]
                     if "id" not in essential_fields:
                         essential_fields.insert(0, "id")
@@ -138,14 +140,18 @@ class CrudToolsMixin:
                     essential_fields = ["id"]
 
                 # Read only the essential fields
-                records = connection.read(model, [record_id], essential_fields)
+                records = await run_blocking(
+                    connection, connection.read, model, [record_id], essential_fields
+                )
                 if not records:
                     raise ValidationError(
                         f"Failed to read created record: {model} with ID {record_id}"
                     )
 
                 # Process dates in the minimal record
-                record = self._process_record_dates(records[0], model, connection)
+                record = await run_blocking(
+                    connection, self._process_record_dates, records[0], model, connection
+                )
 
                 # Generate direct URL to the record in Odoo
                 base_url = (
@@ -194,12 +200,16 @@ class CrudToolsMixin:
                     raise ValidationError("No values provided for record update")
 
                 # Check if record exists (only fetch ID to verify existence)
-                existing = connection.read(model, [record_id], ["id"])
+                existing = await run_blocking(
+                    connection, connection.read, model, [record_id], ["id"]
+                )
                 if not existing:
                     raise NotFoundError(f"Record not found: {model} with ID {record_id}")
 
                 # Update the record
-                success = connection.write(model, [record_id], values)
+                success = await run_blocking(
+                    connection, connection.write, model, [record_id], values
+                )
 
                 # Return only essential fields to minimize context usage
                 # Users can use get_record if they need more fields
@@ -207,7 +217,9 @@ class CrudToolsMixin:
 
                 # Filter to fields that actually exist on this model
                 try:
-                    model_fields = connection.fields_get(model, ["string", "type"])
+                    model_fields = await run_blocking(
+                        connection, connection.fields_get, model, ["string", "type"]
+                    )
                     essential_fields = [f for f in essential_fields if f in model_fields]
                     if "id" not in essential_fields:
                         essential_fields.insert(0, "id")
@@ -215,14 +227,18 @@ class CrudToolsMixin:
                     essential_fields = ["id"]
 
                 # Read only the essential fields
-                records = connection.read(model, [record_id], essential_fields)
+                records = await run_blocking(
+                    connection, connection.read, model, [record_id], essential_fields
+                )
                 if not records:
                     raise ValidationError(
                         f"Failed to read updated record: {model} with ID {record_id}"
                     )
 
                 # Process dates in the minimal record
-                record = self._process_record_dates(records[0], model, connection)
+                record = await run_blocking(
+                    connection, self._process_record_dates, records[0], model, connection
+                )
 
                 # Generate direct URL to the record in Odoo
                 base_url = (
@@ -268,7 +284,7 @@ class CrudToolsMixin:
                     raise ValidationError("Not authenticated with Odoo")
 
                 # Check if record exists
-                existing = connection.read(model, [record_id])
+                existing = await run_blocking(connection, connection.read, model, [record_id])
                 if not existing:
                     raise NotFoundError(f"Record not found: {model} with ID {record_id}")
 
@@ -281,7 +297,7 @@ class CrudToolsMixin:
                 record_name = record.get("name") or record.get("display_name") or f"ID {record_id}"
 
                 # Delete the record
-                success = connection.unlink(model, [record_id])
+                success = await run_blocking(connection, connection.unlink, model, [record_id])
 
                 return {
                     "success": success,

--- a/mcp_server_odoo/tools/introspection.py
+++ b/mcp_server_odoo/tools/introspection.py
@@ -10,7 +10,7 @@ from ..error_handling import ValidationError
 from ..error_sanitizer import ErrorSanitizer
 from ..logging_config import perf_logger
 from ..schemas import ModelsResult, ResourceTemplatesResult, ServerInfoResult
-from ._common import _current_sub, logger
+from ._common import _current_sub, logger, run_blocking
 
 
 class IntrospectionToolsMixin:
@@ -111,8 +111,13 @@ class IntrospectionToolsMixin:
             companies = []
             if is_connected:
                 try:
-                    companies = connection.search_read(
-                        "res.company", [], fields=["id", "name"], limit=10
+                    companies = await run_blocking(
+                        connection,
+                        connection.search_read,
+                        "res.company",
+                        [],
+                        fields=["id", "name"],
+                        limit=10,
                     )
                 except Exception:
                     pass
@@ -142,7 +147,9 @@ class IntrospectionToolsMixin:
                 # handles ACLs server-side. Fetch models from ir.model instead.
                 if not models and hasattr(connection, "search_read"):
                     try:
-                        ir_models = connection.search_read(
+                        ir_models = await run_blocking(
+                            connection,
+                            connection.search_read,
                             "ir.model",
                             [["transient", "=", False]],
                             fields=["model", "name"],

--- a/mcp_server_odoo/tools/messaging.py
+++ b/mcp_server_odoo/tools/messaging.py
@@ -13,7 +13,7 @@ from ..error_sanitizer import ErrorSanitizer
 from ..logging_config import perf_logger
 from ..odoo_connection import OdooConnectionError
 from ..schemas import PostMessageResult
-from ._common import _current_sub, logger
+from ._common import _current_sub, logger, run_blocking
 
 
 class MessagingToolsMixin:
@@ -102,7 +102,14 @@ class MessagingToolsMixin:
 
         Future tools (post_invoice, confirm_sale_order, etc.) reuse this.
         """
-        return connection.call_method(model, method, ids=list(record_ids), **(kwargs or {}))
+        return await run_blocking(
+            connection,
+            connection.call_method,
+            model,
+            method,
+            ids=list(record_ids),
+            **(kwargs or {}),
+        )
 
     async def _handle_post_message_tool(
         self,
@@ -129,7 +136,9 @@ class MessagingToolsMixin:
                     raise ValidationError("body is required and cannot be empty")
 
                 # Verify record exists
-                existing = connection.read(model, [record_id], ["id"])
+                existing = await run_blocking(
+                    connection, connection.read, model, [record_id], ["id"]
+                )
                 if not existing:
                     raise NotFoundError(f"Record not found: {model} with ID {record_id}")
 
@@ -189,17 +198,25 @@ class MessagingToolsMixin:
                     # x_microsoft_message_id only exists when pan_outlook_pro is installed
                     outlook_field = "x_microsoft_message_id"
                     try:
-                        available = connection.fields_get(
-                            "mail.message", [outlook_field], allfields=False
+                        available = await run_blocking(
+                            connection,
+                            connection.fields_get,
+                            "mail.message",
+                            [outlook_field],
+                            allfields=False,
                         )
                     except TypeError:
-                        available = connection.fields_get("mail.message", [outlook_field])
+                        available = await run_blocking(
+                            connection, connection.fields_get, "mail.message", [outlook_field]
+                        )
                     except Exception:
                         available = {}
                     if outlook_field in (available or {}):
                         msg_fields.append(outlook_field)
 
-                    msg_rows = connection.read("mail.message", [message_id], msg_fields)
+                    msg_rows = await run_blocking(
+                        connection, connection.read, "mail.message", [message_id], msg_fields
+                    )
                     msg = msg_rows[0] if msg_rows else {}
                     subtype_pair = msg.get("subtype_id")
                     subtype_name = (
@@ -225,7 +242,9 @@ class MessagingToolsMixin:
                 # Read notifications fan-out
                 notifications: List[Dict[str, Any]] = []
                 try:
-                    notif_rows = connection.search_read(
+                    notif_rows = await run_blocking(
+                        connection,
+                        connection.search_read,
                         "mail.notification",
                         [("mail_message_id", "=", message_id)],
                         [

--- a/mcp_server_odoo/tools/methods.py
+++ b/mcp_server_odoo/tools/methods.py
@@ -23,7 +23,7 @@ from ..error_sanitizer import ErrorSanitizer
 from ..logging_config import perf_logger
 from ..odoo_connection import OdooConnectionError
 from ..schemas import ExecuteMethodResult
-from ._common import _current_sub, logger
+from ._common import _current_sub, logger, run_blocking
 from .wizards import WizardHandler, followup_descriptor, get_handler
 
 _ACTION_SHAPE_KEYS = ("view_mode", "views", "target", "res_id", "domain")
@@ -163,15 +163,29 @@ class MethodsToolsMixin:
                 if not connection.is_authenticated:
                     raise ValidationError("Not authenticated with Odoo")
 
-                value = connection.call_method(model, method, ids=ids, **(kwargs or {}))
+                value = await run_blocking(
+                    connection, connection.call_method, model, method, ids=ids, **(kwargs or {})
+                )
 
                 kind = _classify_result(value)
 
                 if kind == "action":
                     handler = get_handler(value)
                     if handler is not None:
-                        return self._drive_wizard(
-                            connection, handler, value, decision, model, method, ids or []
+                        # _drive_wizard issues further blocking RPC (handler.apply
+                        # -> connection.*); run it off-loop under the same
+                        # connection lock so the wizard completion can't block
+                        # other tenants and can't race the transport.
+                        return await run_blocking(
+                            connection,
+                            self._drive_wizard,
+                            connection,
+                            handler,
+                            value,
+                            decision,
+                            model,
+                            method,
+                            ids or [],
                         )
                     # Known method, but it needs a follow-up wizard we have NOT
                     # validated. We refuse rather than guess: an un-vetted

--- a/mcp_server_odoo/tools/query.py
+++ b/mcp_server_odoo/tools/query.py
@@ -13,7 +13,7 @@ from ..error_sanitizer import ErrorSanitizer
 from ..logging_config import perf_logger
 from ..odoo_connection import OdooConnectionError
 from ..schemas import FieldSelectionMetadata, RecordResult, SearchResult
-from ._common import _current_sub, logger
+from ._common import _current_sub, logger, run_blocking
 
 
 class QueryToolsMixin:
@@ -188,18 +188,30 @@ class QueryToolsMixin:
                     limit = self.config.default_limit
 
                 # Get total count
-                total_count = connection.search_count(model, parsed_domain)
+                total_count = await run_blocking(
+                    connection, connection.search_count, model, parsed_domain
+                )
 
                 # Search for records
-                record_ids = connection.search(
-                    model, parsed_domain, limit=limit, offset=offset, order=order
+                record_ids = await run_blocking(
+                    connection,
+                    connection.search,
+                    model,
+                    parsed_domain,
+                    limit=limit,
+                    offset=offset,
+                    order=order,
                 )
 
                 # Determine which fields to fetch
                 fields_to_fetch = parsed_fields
                 if parsed_fields is None:
-                    # Use smart field selection to avoid serialization issues
-                    fields_to_fetch = self._get_smart_default_fields(model, connection)
+                    # Use smart field selection to avoid serialization issues.
+                    # This may call connection.fields_get (network on a cold
+                    # cache), so run it off-loop under the connection lock.
+                    fields_to_fetch = await run_blocking(
+                        connection, self._get_smart_default_fields, model, connection
+                    )
                     logger.debug(
                         f"Using smart defaults for {model} search: {len(fields_to_fetch) if fields_to_fetch else 'all'} fields"
                     )
@@ -211,11 +223,18 @@ class QueryToolsMixin:
                 # Read records
                 records = []
                 if record_ids:
-                    records = connection.read(model, record_ids, fields_to_fetch)
-                    # Process datetime fields in each record
-                    records = [
-                        self._process_record_dates(record, model, connection) for record in records
-                    ]
+                    records = await run_blocking(
+                        connection, connection.read, model, record_ids, fields_to_fetch
+                    )
+                    # Process datetime fields in each record (may call
+                    # fields_get; keep it off the loop too).
+                    records = await run_blocking(
+                        connection,
+                        lambda recs: [
+                            self._process_record_dates(record, model, connection) for record in recs
+                        ],
+                        records,
+                    )
 
                 return {
                     "records": records,
@@ -258,8 +277,10 @@ class QueryToolsMixin:
                 field_selection_method = "explicit"
 
                 if fields is None:
-                    # Use smart field selection
-                    fields_to_fetch = self._get_smart_default_fields(model, connection)
+                    # Use smart field selection (may hit fields_get -> off-loop)
+                    fields_to_fetch = await run_blocking(
+                        connection, self._get_smart_default_fields, model, connection
+                    )
                     use_smart_defaults = True
                     field_selection_method = "smart_defaults"
                     logger.debug(
@@ -275,19 +296,25 @@ class QueryToolsMixin:
                     logger.debug(f"Fetching specific fields for {model}: {fields}")
 
                 # Read the record
-                records = connection.read(model, [record_id], fields_to_fetch)
+                records = await run_blocking(
+                    connection, connection.read, model, [record_id], fields_to_fetch
+                )
 
                 if not records:
                     raise ValidationError(f"Record not found: {model} with ID {record_id}")
 
-                # Process datetime fields in the record
-                record = self._process_record_dates(records[0], model, connection)
+                # Process datetime fields in the record (may call fields_get)
+                record = await run_blocking(
+                    connection, self._process_record_dates, records[0], model, connection
+                )
 
                 # Build metadata when using smart defaults
                 metadata = None
                 if use_smart_defaults:
                     try:
-                        all_fields_info = connection.fields_get(model)
+                        all_fields_info = await run_blocking(
+                            connection, connection.fields_get, model
+                        )
                         total_fields = len(all_fields_info)
                     except Exception:
                         pass

--- a/tests/test_tools_offload.py
+++ b/tests/test_tools_offload.py
@@ -1,0 +1,194 @@
+"""Concurrency tests for the off-loop Odoo RPC fix (Odoo task #759).
+
+The MCP server runs on a single asyncio event loop and the tool handlers are
+`async def` but the Odoo network calls underneath are synchronous and blocking.
+Before this fix those calls ran directly on the loop, so one tenant's slow Odoo
+froze every other tenant for up to the socket timeout.
+
+These tests prove the two halves of the fix:
+
+1. Calls against *different* connections (different tenants) overlap: two slow
+   calls finish in ~one call's wall time, not two. That only holds if the
+   blocking call left the event loop (asyncio.to_thread).
+
+2. Calls against the *same* connection are serialized by the per-connection
+   lock, so two threads never touch one transport at once. We assert the slow
+   sections never overlap.
+
+The connection is mocked, so no real Odoo is needed.
+"""
+
+import asyncio
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from mcp_server_odoo.access_control import AccessController
+from mcp_server_odoo.config import OdooConfig
+from mcp_server_odoo.odoo_connection import OdooConnection
+from mcp_server_odoo.tools import OdooToolHandler
+
+SLEEP = 0.3  # per-call blocking duration
+
+
+def _make_app():
+    """A fake FastMCP that captures registered tool functions by name."""
+    app = MagicMock(spec=FastMCP)
+    app._tools = {}
+
+    def tool_decorator(**kwargs):
+        def decorator(func):
+            app._tools[func.__name__] = func
+            return func
+
+        return decorator
+
+    app.tool = tool_decorator
+    return app
+
+
+def _make_config():
+    return OdooConfig(
+        url="http://localhost:8069",
+        api_key="test_api_key",
+        database="test_db",
+        default_limit=100,
+        max_limit=500,
+    )
+
+
+def _make_handler(connection):
+    """Build a handler whose _get_user_context returns the given connection."""
+    app = _make_app()
+    access = MagicMock(spec=AccessController)
+    handler = OdooToolHandler(app, connection, access, _make_config())
+    return handler, app
+
+
+def _slow_connection():
+    """A mock connection whose search/read block for SLEEP seconds.
+
+    Smart-default field selection is bypassed (search passes explicit fields)
+    so the only blocking work is the search_count + search + read trio.
+    """
+    conn = MagicMock(spec=OdooConnection)
+    conn.is_authenticated = True
+
+    def slow_search_count(model, domain):
+        time.sleep(SLEEP)
+        return 1
+
+    def slow_search(model, domain, **kwargs):
+        return [1]
+
+    def slow_read(model, ids, fields=None):
+        return [{"id": 1, "name": "x"}]
+
+    conn.search_count.side_effect = slow_search_count
+    conn.search.side_effect = slow_search
+    conn.read.side_effect = slow_read
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_two_tenants_do_not_block_each_other():
+    """Two slow calls on *different* connections run concurrently.
+
+    If the blocking RPC ran on the event loop, the two awaits would serialize
+    and total wall time would be ~2*SLEEP. Off-loop, they overlap at ~1*SLEEP.
+    """
+    conn_a = _slow_connection()
+    conn_b = _slow_connection()
+    handler_a, app_a = _make_handler(conn_a)
+    handler_b, app_b = _make_handler(conn_b)
+
+    search_a = app_a._tools["search_records"]
+    search_b = app_b._tools["search_records"]
+
+    start = time.monotonic()
+    await asyncio.gather(
+        search_a(model="res.partner", domain=[], fields=["name"], limit=10),
+        search_b(model="res.partner", domain=[], fields=["name"], limit=10),
+    )
+    elapsed = time.monotonic() - start
+
+    # Generous bound: overlapping work is ~SLEEP; serialized would be ~2*SLEEP.
+    assert elapsed < 1.8 * SLEEP, (
+        f"two tenants took {elapsed:.2f}s (~{SLEEP}s expected if overlapping); "
+        "the blocking call is likely still on the event loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_event_loop_stays_responsive_during_blocking_call():
+    """The loop keeps running while a tenant's blocking RPC is in flight.
+
+    A 10ms heartbeat coroutine must tick many times during a SLEEP-long call.
+    On the old code (blocking on the loop) it would not tick at all.
+    """
+    conn = _slow_connection()
+    handler, app = _make_handler(conn)
+    search = app._tools["search_records"]
+
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    hb = asyncio.create_task(heartbeat())
+    await search(model="res.partner", domain=[], fields=["name"], limit=10)
+    hb.cancel()
+
+    # SLEEP / 0.01 = ~30 ticks; require a healthy fraction to prove liveness.
+    assert ticks > 5, f"event loop only ticked {ticks} times during a blocking RPC"
+
+
+@pytest.mark.asyncio
+async def test_same_connection_calls_are_serialized():
+    """Two concurrent calls on the SAME connection never run the transport
+    concurrently.
+
+    The XML-RPC ServerProxy / curl_cffi Session backing a single connection is
+    not safe for concurrent thread use. The per-connection asyncio.Lock must
+    serialize same-connection calls. We detect any overlap inside the blocking
+    section via a non-reentrant counter.
+    """
+    conn = MagicMock(spec=OdooConnection)
+    conn.is_authenticated = True
+
+    in_flight = 0
+    max_in_flight = 0
+    guard = threading.Lock()
+
+    def slow_search_count(model, domain):
+        nonlocal in_flight, max_in_flight
+        with guard:
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+        time.sleep(SLEEP)
+        with guard:
+            in_flight -= 1
+        return 1
+
+    conn.search_count.side_effect = slow_search_count
+    conn.search.side_effect = lambda model, domain, **kw: [1]
+    conn.read.side_effect = lambda model, ids, fields=None: [{"id": 1}]
+
+    handler, app = _make_handler(conn)
+    search = app._tools["search_records"]
+
+    await asyncio.gather(
+        search(model="res.partner", domain=[], fields=["name"], limit=10),
+        search(model="res.partner", domain=[], fields=["name"], limit=10),
+    )
+
+    assert max_in_flight == 1, (
+        f"same-connection transport ran {max_in_flight} calls at once; "
+        "the per-connection lock failed to serialize them"
+    )


### PR DESCRIPTION
## What changed

The MCP server runs on a single asyncio event loop, but the tool handlers were `async def` while the Odoo network calls under them (`connection.search` / `read` / `write` / `create` / `unlink` / `fields_get` / `search_count` / `search_read` / `call_method` / `create_bulk` / `load_records`) are synchronous and blocking. They ran **directly on the loop**, so one tenant's slow Odoo (up to the ~30s socket timeout) froze every other tenant's request. Previously only version detection had been moved off-loop.

Every blocking Odoo network call in the tool mixins now goes through a new `run_blocking()` helper in `tools/_common.py` that hands the call to a worker thread via `asyncio.to_thread`. Files touched:

- `tools/_common.py` - new `run_blocking()` + per-connection lock registry
- `tools/query.py` - search_records, get_record
- `tools/crud.py` - create/update/delete_record
- `tools/bulk.py` - create/update/delete_records, import_records
- `tools/binary.py` - set_binary_field (existing upload semaphore kept)
- `tools/messaging.py` - post_message + `_call_record_method`
- `tools/introspection.py` - list_models, server_info
- `tools/methods.py` - execute_method (incl. the wizard-completion path)

Sync formatting helpers that themselves issue a (cached) `fields_get` - smart-default field selection and datetime processing - are run via the same helper, so a cold cache can't block the loop either. The `wizards.py` `connection.*` calls are not wrapped individually on purpose: they run inside `_drive_wizard`, which is itself dispatched through `run_blocking`, so they already execute in the worker thread under the connection lock.

## Thread-safety analysis and decision

Moving calls to threads means two concurrent requests for the **same** user (who share one cached connection object) could otherwise hit the same transport from two threads. The underlying transports are **not** safe for that:

- XML-RPC: a single `xmlrpc.client.ServerProxy` (`_object_proxy`) is reused for every ORM call - one persistent socket. Concurrent calls would interleave request/response framing and corrupt results.
- JSON/2: a single `curl_cffi.Session` is reused, plus an unlocked `_fields_cache` dict.

The `threading.RLock`s in `performance.py` / `performance_cache.py` only guard the connection-pool list and the cache maps; they do **not** make a live transport safe for concurrent use.

**Decision: serialize per connection, never globally.** `run_blocking` holds a per-connection `asyncio.Lock` (stored in a `WeakKeyDictionary` keyed on the connection object, so it's freed when the connection is evicted) around the `to_thread` call. Same-user calls take turns on their shared connection; **different tenants hold different connections and run truly in parallel**. A global lock was deliberately rejected because it would reintroduce the very cross-tenant head-of-line blocking this PR removes.

## Test approach

New `tests/test_tools_offload.py` (connection fully mocked, no real Odoo):

1. `test_two_tenants_do_not_block_each_other` - two slow calls on different connections finish in ~1x wall time via `asyncio.gather`, not 2x (fails if the blocking call is still on the loop).
2. `test_event_loop_stays_responsive_during_blocking_call` - a 10ms heartbeat coroutine keeps ticking while a blocking RPC is in flight.
3. `test_same_connection_calls_are_serialized` - a non-reentrant in-flight counter proves the transport never runs two same-connection calls at once.

Results: `536 passed, 98 skipped` (3 new). `ruff check`, `ruff format --check`, and `scripts/check_max_lines.py` all pass.

Fixes the all-tenants-freeze issue (Odoo task #759).

🤖 Generated with [Claude Code](https://claude.com/claude-code)