### PR TITLE
chore: release 2.3.0

### DIFF
--- a/mcp_server_odoo/__init__.py
+++ b/mcp_server_odoo/__init__.py
@@ -1,6 +1,6 @@
 """MCP Server for Odoo - Model Context Protocol server for Odoo ERP systems."""
 
-__version__ = "2.0.0"
+__version__ = "2.3.0"
 __author__ = "Andrey Ivanov"
 __license__ = "MPL-2.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-server-odoo"
-version = "2.2.0"
+version = "2.3.0"
 description = "AI connector for Odoo ERP -- connect Claude, ChatGPT, and other AI tools to Odoo via MCP (Model Context Protocol)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Version bump for the next release tag (v2.3.0), so the admin package can pin a build that includes:

- fix(tools): run blocking Odoo RPC off the event loop, per-connection lock (#79, task #759)
- feat(tools): optional per-call connection selector + server_info `connections` (#80, task #758)
- fix(delete_record): handle records with no name (#69)

Also aligns `__init__.__version__` (was lagging at 2.0.0) with pyproject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)