### PR TITLE
feat(connections): per-call connection selection + ambiguous-write guard hook

### DIFF
--- a/mcp_server_odoo/__init__.py
+++ b/mcp_server_odoo/__init__.py
@@ -1,6 +1,6 @@
 """MCP Server for Odoo - Model Context Protocol server for Odoo ERP systems."""
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 __author__ = "Andrey Ivanov"
 __license__ = "MPL-2.0"
 

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -34,22 +34,31 @@ from .version_detect import detect_api_version
 logger = get_logger(__name__)
 
 # Server version — keep in sync with pyproject.toml
-SERVER_VERSION = "2.2.0"
+SERVER_VERSION = "2.3.1"
 GIT_COMMIT = os.environ.get("GIT_COMMIT", "unknown")
 _BUILD_ORIGIN = "pnl-mcp-7f3a"  # Pantalytics provenance tag
 
 
-def create_fastmcp_app(*, auth=None, token_verifier=None) -> FastMCP:
+def create_fastmcp_app(
+    *, auth=None, token_verifier=None, extra_instructions: str | None = None
+) -> FastMCP:
     """Create the FastMCP app with the canonical server settings.
 
     Single source of truth for FastMCP construction — used by OdooMCPServer
     and by the private admin package's multi-tenant entry point. stateless_http
     so any replica can serve any request (blue/green deploys don't drop client
     connections with "No transport found for sessionId").
+
+    ``extra_instructions`` is appended to the handshake instructions. Self-hosted
+    (single connection) passes nothing; the multi-tenant admin layer uses it to
+    teach the client about choosing between several live connections.
     """
+    instructions = SERVER_INSTRUCTIONS
+    if extra_instructions:
+        instructions = f"{instructions}\n{extra_instructions}"
     app = FastMCP(
         name="odoo-mcp-server",
-        instructions=SERVER_INSTRUCTIONS,
+        instructions=instructions,
         auth=auth,
         token_verifier=token_verifier,
         stateless_http=True,

--- a/mcp_server_odoo/tools/binary.py
+++ b/mcp_server_odoo/tools/binary.py
@@ -113,7 +113,7 @@ class BinaryToolsMixin:
         try:
             async with _BINARY_UPLOAD_SEMAPHORE:
                 connection, access_controller, sub = await self._get_user_context(
-                    connection_selector
+                    connection_selector, writes=True
                 )
                 with perf_logger.track_operation("tool_set_binary_field", model=model):
                     access_controller.validate_model_access(model, "write")

--- a/mcp_server_odoo/tools/bulk.py
+++ b/mcp_server_odoo/tools/bulk.py
@@ -191,7 +191,9 @@ class BulkToolsMixin:
     ) -> Dict[str, Any]:
         """Handle bulk create tool request."""
         try:
-            connection, access_controller, sub = await self._get_user_context(connection_selector)
+            connection, access_controller, sub = await self._get_user_context(
+                connection_selector, writes=True
+            )
             with perf_logger.track_operation("tool_create_records", model=model):
                 access_controller.validate_model_access(model, "create")
                 if not connection.is_authenticated:
@@ -235,7 +237,9 @@ class BulkToolsMixin:
     ) -> Dict[str, Any]:
         """Handle bulk update tool request."""
         try:
-            connection, access_controller, sub = await self._get_user_context(connection_selector)
+            connection, access_controller, sub = await self._get_user_context(
+                connection_selector, writes=True
+            )
             with perf_logger.track_operation("tool_update_records", model=model):
                 access_controller.validate_model_access(model, "write")
                 if not connection.is_authenticated:
@@ -278,7 +282,9 @@ class BulkToolsMixin:
     ) -> Dict[str, Any]:
         """Handle bulk delete tool request."""
         try:
-            connection, access_controller, sub = await self._get_user_context(connection_selector)
+            connection, access_controller, sub = await self._get_user_context(
+                connection_selector, writes=True
+            )
             with perf_logger.track_operation("tool_delete_records", model=model):
                 access_controller.validate_model_access(model, "unlink")
                 if not connection.is_authenticated:
@@ -321,7 +327,9 @@ class BulkToolsMixin:
     ) -> Dict[str, Any]:
         """Handle import_records tool request using Odoo's load() method."""
         try:
-            connection, access_controller, sub = await self._get_user_context(connection_selector)
+            connection, access_controller, sub = await self._get_user_context(
+                connection_selector, writes=True
+            )
             with perf_logger.track_operation("tool_import_records", model=model):
                 access_controller.validate_model_access(model, "create")
                 access_controller.validate_model_access(model, "write")

--- a/mcp_server_odoo/tools/crud.py
+++ b/mcp_server_odoo/tools/crud.py
@@ -121,7 +121,9 @@ class CrudToolsMixin:
     ) -> Dict[str, Any]:
         """Handle create record tool request."""
         try:
-            connection, access_controller, sub = await self._get_user_context(connection_selector)
+            connection, access_controller, sub = await self._get_user_context(
+                connection_selector, writes=True
+            )
             with perf_logger.track_operation("tool_create_record", model=model):
                 # Check model access
                 access_controller.validate_model_access(model, "create")
@@ -200,7 +202,9 @@ class CrudToolsMixin:
     ) -> Dict[str, Any]:
         """Handle update record tool request."""
         try:
-            connection, access_controller, sub = await self._get_user_context(connection_selector)
+            connection, access_controller, sub = await self._get_user_context(
+                connection_selector, writes=True
+            )
             with perf_logger.track_operation("tool_update_record", model=model):
                 # Check model access
                 access_controller.validate_model_access(model, "write")
@@ -289,7 +293,9 @@ class CrudToolsMixin:
     ) -> Dict[str, Any]:
         """Handle delete record tool request."""
         try:
-            connection, access_controller, sub = await self._get_user_context(connection_selector)
+            connection, access_controller, sub = await self._get_user_context(
+                connection_selector, writes=True
+            )
             with perf_logger.track_operation("tool_delete_record", model=model):
                 # Check model access
                 access_controller.validate_model_access(model, "unlink")

--- a/mcp_server_odoo/tools/handler.py
+++ b/mcp_server_odoo/tools/handler.py
@@ -57,6 +57,8 @@ class OdooToolHandler(
     async def _get_user_context(
         self,
         connection: Optional[str] = None,
+        *,
+        writes: bool = False,
     ) -> Tuple[OdooConnectionProtocol, AccessController, str]:
         """Get connection and access controller for the current request.
 
@@ -66,6 +68,10 @@ class OdooToolHandler(
         Args:
             connection: optional connection selector, honored only by the
                 multi-tenant hosted handler; ignored in single-connection mode.
+            writes: True for tools that mutate Odoo. The multi-tenant handler
+                uses it to refuse an ambiguous write (several connections active,
+                none named) so it cannot hit the wrong database; ignored in
+                single-connection mode, where there is nothing to disambiguate.
 
         Returns:
             Tuple of (connection, access_controller, sub)

--- a/mcp_server_odoo/tools/messaging.py
+++ b/mcp_server_odoo/tools/messaging.py
@@ -130,7 +130,9 @@ class MessagingToolsMixin:
     ) -> Dict[str, Any]:
         """Handle post_message tool request."""
         try:
-            connection, access_controller, sub = await self._get_user_context(connection_selector)
+            connection, access_controller, sub = await self._get_user_context(
+                connection_selector, writes=True
+            )
             with perf_logger.track_operation("tool_post_message", model=model):
                 # Posting to chatter requires write access on the model
                 access_controller.validate_model_access(model, "write")

--- a/mcp_server_odoo/tools/methods.py
+++ b/mcp_server_odoo/tools/methods.py
@@ -149,7 +149,9 @@ class MethodsToolsMixin:
     ) -> Dict[str, Any]:
         """Handle execute_method tool request."""
         try:
-            connection, access_controller, sub = await self._get_user_context(connection_selector)
+            connection, access_controller, sub = await self._get_user_context(
+                connection_selector, writes=True
+            )
             with perf_logger.track_operation("tool_execute_method", model=model):
                 if not method or not method.strip():
                     raise ValidationError("method is required")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-server-odoo"
-version = "2.3.0"
+version = "2.3.1"
 description = "AI connector for Odoo ERP -- connect Claude, ChatGPT, and other AI tools to Odoo via MCP (Model Context Protocol)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_connection_selector.py
+++ b/tests/test_connection_selector.py
@@ -6,7 +6,9 @@ mode there is a single connection, so the selector is ignored. These tests pin
 two contracts:
 
 1. Every tool that resolves a connection forwards its `connection` argument
-   (and None when omitted) to `_get_user_context`.
+   (and None when omitted) to `_get_user_context`. Mutating tools also pass
+   `writes=True` so the hosted layer can refuse an ambiguous write; read tools
+   do not.
 2. server_info exposes a `connections` list iff `_available_connections`
    returns one, and omits it (None) otherwise.
 
@@ -101,7 +103,7 @@ class TestSelectorForwarding:
             model="res.partner", values={"name": "x"}, connection="7"
         )
 
-        ctx.assert_awaited_once_with("7")
+        ctx.assert_awaited_once_with("7", writes=True)
 
     @pytest.mark.asyncio
     async def test_update_record_forwards_selector(
@@ -116,7 +118,7 @@ class TestSelectorForwarding:
             model="res.partner", record_id=1, values={"name": "y"}, connection="7"
         )
 
-        ctx.assert_awaited_once_with("7")
+        ctx.assert_awaited_once_with("7", writes=True)
 
     @pytest.mark.asyncio
     async def test_delete_record_forwards_selector(
@@ -128,7 +130,7 @@ class TestSelectorForwarding:
 
         await mock_app._tools["delete_record"](model="res.partner", record_id=1, connection="7")
 
-        ctx.assert_awaited_once_with("7")
+        ctx.assert_awaited_once_with("7", writes=True)
 
     @pytest.mark.asyncio
     async def test_create_records_forwards_selector(
@@ -141,7 +143,7 @@ class TestSelectorForwarding:
             model="res.partner", vals_list=[{"name": "a"}, {"name": "b"}], connection="7"
         )
 
-        ctx.assert_awaited_once_with("7")
+        ctx.assert_awaited_once_with("7", writes=True)
 
     @pytest.mark.asyncio
     async def test_update_records_forwards_selector(
@@ -154,7 +156,7 @@ class TestSelectorForwarding:
             model="res.partner", record_ids=[1, 2], values={"name": "y"}, connection="7"
         )
 
-        ctx.assert_awaited_once_with("7")
+        ctx.assert_awaited_once_with("7", writes=True)
 
     @pytest.mark.asyncio
     async def test_delete_records_forwards_selector(
@@ -167,7 +169,7 @@ class TestSelectorForwarding:
             model="res.partner", record_ids=[1, 2], connection="7"
         )
 
-        ctx.assert_awaited_once_with("7")
+        ctx.assert_awaited_once_with("7", writes=True)
 
     @pytest.mark.asyncio
     async def test_import_records_forwards_selector(
@@ -183,7 +185,7 @@ class TestSelectorForwarding:
             connection="7",
         )
 
-        ctx.assert_awaited_once_with("7")
+        ctx.assert_awaited_once_with("7", writes=True)
 
     @pytest.mark.asyncio
     async def test_list_models_forwards_selector(
@@ -209,7 +211,7 @@ class TestSelectorForwarding:
             model="sale.order", method="action_confirm", ids=[1], connection="7"
         )
 
-        ctx.assert_awaited_once_with("7")
+        ctx.assert_awaited_once_with("7", writes=True)
 
 
 class TestServerInfoConnections:


### PR DESCRIPTION
Part of the multi-connection UX work (admin PR is the companion). Public-side seam only; self-hosted single-connection behavior is unchanged.

## What
- `create_fastmcp_app(extra_instructions=...)` so the multi-tenant admin layer can append guidance about choosing between several live connections. Default `None` keeps current behavior.
- Mutating tools (crud/bulk/methods/messaging/binary) forward `writes=True` to `_get_user_context`. The hosted layer uses it to refuse an ambiguous write (several connections active, none named); reads and standalone mode are untouched.
- Version bump to 2.3.1 (`SERVER_VERSION` was lagging at 2.2.0; aligned pyproject + `__init__`).

## Tests
- `tests/test_connection_selector.py` updated: write tools now assert `writes=True`; reads unchanged.
- Full suite green locally (551 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)