### PR TITLE
feat(execute_method): support contact merge wizard with elicitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 
 ## [Unreleased]
 
+### Added
+- **Merge duplicate contacts via `execute_method`**: `base.partner.merge.automatic.wizard` / `action_merge` is now a supported entry wizard. Pass the contacts to merge in `ids`; omit `decision` to be told the one choice (`dst_partner_id`, the contact to keep), then re-call with `decision={"dst_partner_id": <id>}`. Odoo's merge method does its work and then returns an action that only reopens the (finished) wizard, so previously the caller saw a false "not supported, nothing changed" while the merge had in fact happened, a dangerous false negative on an irreversible action. The call is now intercepted before the raw method fires (so discovery never merges), driven to completion, and reported as `completed`. It refuses clearly when fewer than two contacts are given or the survivor is not among them.
+
 ## [2.2.0] - 2026-06-18
 
 ### Added

--- a/mcp_server_odoo/tools/methods.py
+++ b/mcp_server_odoo/tools/methods.py
@@ -24,7 +24,7 @@ from ..logging_config import perf_logger
 from ..odoo_connection import OdooConnectionError
 from ..schemas import ExecuteMethodResult
 from ._common import _current_sub, logger, run_blocking
-from .wizards import WizardHandler, followup_descriptor, get_handler
+from .wizards import WizardHandler, followup_descriptor, get_entry_handler, get_handler
 
 _ACTION_SHAPE_KEYS = ("view_mode", "views", "target", "res_id", "domain")
 
@@ -107,6 +107,12 @@ class MethodsToolsMixin:
             re-call with `decision` filled in. This two-step flow is stateless: it
             needs no live back-and-forth with your client.
 
+            Merging duplicate contacts uses the same flow: call
+            model='base.partner.merge.automatic.wizard', method='action_merge'
+            with `ids` set to the contact ids to merge. Omit `decision` to be told
+            the one choice (dst_partner_id, the contact to keep), then re-call with
+            decision={"dst_partner_id": <id>}. The merge cannot be undone.
+
             Args:
                 model: Odoo model name, e.g. 'sale.order', 'account.move'.
                 method: Public method to call, e.g. 'action_confirm',
@@ -169,6 +175,29 @@ class MethodsToolsMixin:
 
                 if not connection.is_authenticated:
                     raise ValidationError("Not authenticated with Odoo")
+
+                # Entry wizards (e.g. contact merge) do their work inside their
+                # own action_* method and only return an act_window that reopens
+                # themselves. We must NOT fire that raw method to "discover" it --
+                # that would already perform the merge. Intercept before the RPC
+                # and route through the same discover/complete flow instead.
+                entry_handler = get_entry_handler(model, method)
+                if entry_handler is not None:
+                    synthetic_action = {
+                        "type": "ir.actions.act_window",
+                        "res_model": entry_handler.res_model,
+                    }
+                    return await run_blocking(
+                        connection,
+                        self._drive_wizard,
+                        connection,
+                        entry_handler,
+                        synthetic_action,
+                        decision,
+                        model,
+                        method,
+                        ids or [],
+                    )
 
                 value = await run_blocking(
                     connection, connection.call_method, model, method, ids=ids, **(kwargs or {})

--- a/mcp_server_odoo/tools/wizards.py
+++ b/mcp_server_odoo/tools/wizards.py
@@ -22,11 +22,12 @@ context as an unevaluated string).
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, Field
 
 from ..connection_protocol import OdooConnectionProtocol
+from ..error_handling import ValidationError
 
 # --- Per-wizard decision schemas (primitive fields only, per the MCP
 #     elicitation spec: no nested objects or arrays of objects). ---
@@ -78,6 +79,21 @@ class ReverseMovesDecision(BaseModel):
     )
     journal_id: Optional[int] = Field(
         default=None, description="Journal for the credit note. Omit for the move's own journal."
+    )
+
+
+class MergePartnersDecision(BaseModel):
+    """Decision for the base.partner.merge.automatic.wizard (merge duplicate
+    contacts). The contacts to merge are the recordset passed in `ids`; the one
+    field here is which of them survives."""
+
+    dst_partner_id: int = Field(
+        description=(
+            "Id of the contact to KEEP (the survivor). Must be one of the ids "
+            "passed in `ids`. Every other contact in `ids` is merged into it "
+            "(their messages, activities and references are moved over) and then "
+            "removed. This CANNOT be undone."
+        ),
     )
 
 
@@ -217,6 +233,55 @@ def _apply_reverse_moves(
     }
 
 
+def _apply_merge_partners(
+    connection: OdooConnectionProtocol,
+    action: Dict[str, Any],
+    data: Dict[str, Any],
+    origin_model: str,
+    origin_ids: List[int],
+) -> Dict[str, Any]:
+    """Merge duplicate res.partner records via Odoo's own merge wizard.
+
+    Unlike the follow-up wizards above, this is an ENTRY wizard: no upstream
+    method hands us an action, so `origin_ids` are the CONTACT ids to merge (the
+    recordset the caller aimed the merge at), not wizard ids. We create the
+    transient wizard with those partners and the chosen survivor, then call the
+    wizard's own action_merge. action_merge performs the merge and returns an
+    act_window that just reopens the (now finished) wizard -- the merge is done
+    by the time it returns. Validated against live Odoo (see PR).
+    """
+    partner_ids = list(origin_ids or [])
+    if len(partner_ids) < 2:
+        raise ValidationError(
+            "Merging contacts needs at least two contact ids in `ids` "
+            "(the duplicates to merge together)."
+        )
+    dst = data.get("dst_partner_id")
+    if dst not in partner_ids:
+        raise ValidationError(
+            f"dst_partner_id ({dst}) must be one of the contact ids in `ids` "
+            f"{partner_ids} -- it is the contact to keep."
+        )
+    # default_get of the merge wizard reads active_ids (res.partner) to populate
+    # partner_ids; we also pass partner_ids explicitly so it is self-contained.
+    ctx = {
+        "active_model": "res.partner",
+        "active_ids": partner_ids,
+        "active_id": partner_ids[0],
+    }
+    vals = {"partner_ids": [(6, 0, partner_ids)], "dst_partner_id": dst}
+    wiz_id = connection.create("base.partner.merge.automatic.wizard", vals, context=ctx)
+    result = connection.call_method(
+        "base.partner.merge.automatic.wizard", "action_merge", ids=[wiz_id], context=ctx
+    )
+    merged = len(partner_ids) - 1
+    return {
+        "completion_method": "action_merge",
+        "result": result,
+        "message": f"Merged {merged} duplicate contact(s) into contact {dst}.",
+    }
+
+
 class WizardHandler:
     """Knows how to ask the follow-up and how to complete one wizard."""
 
@@ -266,6 +331,30 @@ def get_handler(action: Optional[Dict[str, Any]]) -> Optional[WizardHandler]:
     if not isinstance(action, dict):
         return None
     return WIZARD_REGISTRY.get(action.get("res_model"))
+
+
+# --- Entry wizards: driven by a direct (model, method) call, not by an action
+#     Odoo hands back. These do the work inside their own action_* method (Odoo's
+#     merge wizard merges, then returns an act_window that just reopens itself),
+#     so we intercept the call BEFORE hitting Odoo and route it through the same
+#     discover/complete flow. Kept out of WIZARD_REGISTRY so the reopen action
+#     they return is NOT mistaken for a further follow-up. ---
+
+ENTRY_WIZARD_REGISTRY: Dict[Tuple[str, str], WizardHandler] = {
+    ("base.partner.merge.automatic.wizard", "action_merge"): WizardHandler(
+        "base.partner.merge.automatic.wizard",
+        MergePartnersDecision,
+        _apply_merge_partners,
+        "Merge these contacts into one? Pass the contacts as `ids` and "
+        "dst_partner_id (the contact to keep); the others are merged in and "
+        "removed. This cannot be undone.",
+    ),
+}
+
+
+def get_entry_handler(model: str, method: str) -> Optional[WizardHandler]:
+    """Return the handler for a wizard invoked directly, or None if unknown."""
+    return ENTRY_WIZARD_REGISTRY.get((model, method))
 
 
 def followup_descriptor(handler: WizardHandler) -> Dict[str, Any]:

--- a/tests/test_wizards.py
+++ b/tests/test_wizards.py
@@ -373,3 +373,106 @@ class TestUndoWizards:
             "account.move.reversal",
             "reverse_moves",
         )
+
+
+class TestMergeContactsEntryWizard:
+    """Contact merge is an ENTRY wizard: the caller invokes the wizard's
+    action_merge directly (no upstream Odoo action), `ids` are the contacts to
+    merge, and the single decision is which one survives. The raw method is NEVER
+    fired to 'discover' -- that would already perform the merge."""
+
+    @pytest.fixture
+    def mock_app(self):
+        app = Mock()
+        app.tool = Mock(side_effect=lambda **kwargs: lambda func: func)
+        return app
+
+    @pytest.fixture
+    def mock_connection(self):
+        conn = Mock()
+        conn.is_authenticated = True
+        conn._base_url = "http://localhost:8069"
+        return conn
+
+    @pytest.fixture
+    def handler(self, mock_app, mock_connection):
+        ac = Mock()
+        ac.validate_model_access = Mock()
+        config = Mock()
+        config.url = "http://localhost:8069"
+        return OdooToolHandler(mock_app, mock_connection, ac, config)
+
+    @pytest.mark.asyncio
+    async def test_no_decision_defers_without_touching_odoo(self, handler, mock_connection):
+        """Discover must NOT call the wizard (no merge on discovery)."""
+        result = await handler._handle_execute_method_tool(
+            "base.partner.merge.automatic.wizard", "action_merge", ids=[35, 36]
+        )
+
+        assert result["result_kind"] == "action"
+        assert result["followup"]["wizard"] == "base.partner.merge.automatic.wizard"
+        assert "dst_partner_id" in result["followup"]["decision_fields"]
+        mock_connection.call_method.assert_not_called()
+        mock_connection.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_decision_merges_into_survivor(self, handler, mock_connection):
+        """A decision creates the wizard with the contacts + survivor and calls
+        action_merge once. action_merge returns a reopen action; the merge is
+        already done, so we report 'completed', not 'unsupported'."""
+        reopen = {
+            "type": "ir.actions.act_window",
+            "res_model": "base.partner.merge.automatic.wizard",
+            "res_id": 1,
+        }
+        mock_connection.call_method.return_value = reopen
+        mock_connection.create.return_value = 1
+
+        result = await handler._handle_execute_method_tool(
+            "base.partner.merge.automatic.wizard",
+            "action_merge",
+            ids=[35, 36],
+            decision={"dst_partner_id": 35},
+        )
+
+        assert result["result_kind"] == "completed"
+        model_arg, vals_arg = mock_connection.create.call_args.args
+        assert model_arg == "base.partner.merge.automatic.wizard"
+        assert vals_arg == {"partner_ids": [(6, 0, [35, 36])], "dst_partner_id": 35}
+        ctx = mock_connection.create.call_args.kwargs["context"]
+        assert ctx["active_model"] == "res.partner"
+        assert ctx["active_ids"] == [35, 36]
+        # Exactly one wizard call: action_merge on the created wizard.
+        assert mock_connection.call_method.call_count == 1
+        assert mock_connection.call_method.call_args.args[:2] == (
+            "base.partner.merge.automatic.wizard",
+            "action_merge",
+        )
+        assert mock_connection.call_method.call_args.kwargs["ids"] == [1]
+
+    @pytest.mark.asyncio
+    async def test_survivor_must_be_in_ids(self, handler, mock_connection):
+        """dst_partner_id outside `ids` is refused before any merge runs."""
+        with pytest.raises(ValidationError, match="must be one of the contact ids"):
+            await handler._handle_execute_method_tool(
+                "base.partner.merge.automatic.wizard",
+                "action_merge",
+                ids=[35, 36],
+                decision={"dst_partner_id": 99},
+            )
+
+        mock_connection.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_needs_at_least_two_contacts(self, handler, mock_connection):
+        """A single id (e.g. someone passing a wizard id the old way) cannot
+        silently merge; it errors before creating anything."""
+        with pytest.raises(ValidationError, match="at least two contact ids"):
+            await handler._handle_execute_method_tool(
+                "base.partner.merge.automatic.wizard",
+                "action_merge",
+                ids=[1],
+                decision={"dst_partner_id": 1},
+            )
+
+        mock_connection.create.assert_not_called()


### PR DESCRIPTION
## What

Makes merging duplicate contacts work through `execute_method`, as a supported wizard with the same stateless two-step (elicitation) flow the other wizards use.

Call it with:

```
execute_method(model="base.partner.merge.automatic.wizard", method="action_merge", ids=[<contact ids>])
# -> followup asks for the one choice: dst_partner_id (the contact to keep)
execute_method(..., ids=[<contact ids>], decision={"dst_partner_id": <id>})
# -> merged, result_kind "completed"
```

## Why

Daniel asked whether merge works via the MCP. It does at the Odoo level, but the server reported it as broken. Odoo's `action_merge` performs the merge and *then* returns an `act_window` that just reopens the (now finished) wizard. The generic action handling saw an unknown wizard action and returned **"not supported, nothing changed"** while the merge had in fact already happened. That is a false negative on an irreversible, destructive action, the worst kind: the agent thinks nothing happened and may retry.

Verified against a live Odoo instance: creating the wizard with `partner_ids` + `dst_partner_id` and calling `action_merge` merges and deletes the duplicates.

## How

- **Entry wizards**: a new small concept in `wizards.py` for wizards you invoke directly (no upstream Odoo action). `execute_method` intercepts `(model, method)` matches *before* the raw RPC fires, so discovery never triggers the merge, then routes through the existing `_drive_wizard` discover/complete flow.
- Kept out of the follow-up `WIZARD_REGISTRY` so the reopen action `action_merge` returns is not mistaken for a further wizard step (it is reported as `completed`).
- `ids` are the contacts to merge; the single decision field is `dst_partner_id` (the survivor). Refuses clearly on fewer than two contacts or a survivor not in `ids`.

## Tests

Added `TestMergeContactsEntryWizard` (discovery does not touch Odoo, decision merges into the survivor with the right vals/context, survivor-must-be-in-ids, min-two-contacts). Full suite: 554 passed, 98 skipped. ruff clean, both touched files under the 500-line budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)