### PR TITLE
license: restore MPL-2.0 attribution for files derived from mcp-server-odoo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 
 ## [Unreleased]
 
+## [2.3.2] - 2026-07-11
+
+### Changed
+- Licensing now reflects the project's origins. odoo-mcp-pro is a fork of
+  [mcp-server-odoo](https://github.com/ivnvxd/mcp-server-odoo) by Andrey Ivanov
+  (MPL-2.0). The files derived from that project keep their Mozilla Public
+  License 2.0, each with an `SPDX-License-Identifier: MPL-2.0` header, and the
+  full text now ships as `LICENSE.MPL-2.0`. A new `NOTICE` file lists every
+  MPL-covered file. The code Pantalytics added on top (for example
+  `execute_method`, the merge wizards, bulk import, and `post_message`) stays
+  under the Elastic License 2.0. No runtime behavior changes.
+
 ## [2.2.0] - 2026-06-18
 
 ### Added

--- a/LICENSE.MPL-2.0
+++ b/LICENSE.MPL-2.0
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,66 @@
+odoo-mcp-pro
+============
+
+This project is a derivative of mcp-server-odoo by Andrey Ivanov
+(https://github.com/ivnvxd/mcp-server-odoo), which is licensed under the
+Mozilla Public License 2.0 (MPL-2.0).
+
+Licensing
+---------
+
+odoo-mcp-pro is dual-licensed:
+
+1. Files derived from mcp-server-odoo remain licensed under the Mozilla Public
+   License 2.0. Each such file carries an "SPDX-License-Identifier: MPL-2.0"
+   header. The full license text is in LICENSE.MPL-2.0.
+
+2. All other files -- the parts Pantalytics B.V. added on top -- are licensed
+   under the Elastic License 2.0. The full text is in LICENSE.
+
+Under MPL-2.0, the source of the MPL-covered files (including any modifications
+Pantalytics made to them) stays available under MPL-2.0. The Elastic License 2.0
+applies only to the newly added, non-MPL files.
+
+MPL-2.0 covered files
+---------------------
+
+The following files are derived from mcp-server-odoo and are licensed under
+MPL-2.0. Copyright 2025 Andrey Ivanov <ivnv.xd@gmail.com>, with modifications
+copyright 2025-2026 Pantalytics B.V.
+
+  mcp_server_odoo/__init__.py
+  mcp_server_odoo/__main__.py
+  mcp_server_odoo/access_control.py
+  mcp_server_odoo/config.py
+  mcp_server_odoo/error_handling.py
+  mcp_server_odoo/error_handler.py
+  mcp_server_odoo/error_sanitizer.py
+  mcp_server_odoo/exceptions.py
+  mcp_server_odoo/formatters.py
+  mcp_server_odoo/logging_config.py
+  mcp_server_odoo/performance.py
+  mcp_server_odoo/performance_cache.py
+  mcp_server_odoo/schemas.py
+  mcp_server_odoo/server.py
+  mcp_server_odoo/uri_schema.py
+  mcp_server_odoo/odoo_connection/__init__.py
+  mcp_server_odoo/odoo_connection/auth.py
+  mcp_server_odoo/odoo_connection/core.py
+  mcp_server_odoo/odoo_connection/orm.py
+  mcp_server_odoo/resources/__init__.py
+  mcp_server_odoo/resources/formatting.py
+  mcp_server_odoo/resources/handler.py
+  mcp_server_odoo/resources/retrieval.py
+  mcp_server_odoo/tools/__init__.py
+  mcp_server_odoo/tools/_common.py
+  mcp_server_odoo/tools/crud.py
+  mcp_server_odoo/tools/formatting.py
+  mcp_server_odoo/tools/handler.py
+  mcp_server_odoo/tools/introspection.py
+  mcp_server_odoo/tools/query.py
+
+The SPDX header on each file is authoritative; if this list and the headers ever
+disagree, the header wins. New tools added by Pantalytics (for example
+tools/methods.py, tools/wizards.py, tools/binary.py, tools/bulk.py,
+tools/messaging.py) and other new modules are Elastic License 2.0 and do not
+carry an MPL header.

--- a/README.md
+++ b/README.md
@@ -179,13 +179,18 @@ Hosted, unless you have a strong reason not to. Hosted is running in 5 minutes, 
 
 ## License
 
-[Elastic License 2.0](LICENSE). In plain terms:
+This project is dual-licensed:
+
+- Files derived from the original [mcp-server-odoo](https://github.com/ivnvxd/mcp-server-odoo) by Andrey Ivanov stay under the **Mozilla Public License 2.0** ([LICENSE.MPL-2.0](LICENSE.MPL-2.0)). These files carry an `SPDX-License-Identifier: MPL-2.0` header, and [NOTICE](NOTICE) lists them.
+- Everything else -- the code Pantalytics added on top -- is under the **[Elastic License 2.0](LICENSE)**.
+
+For the Elastic-licensed parts, in plain terms:
 
 - **You may** use, copy, modify, and distribute this software -- including for your own commercial purposes (running it inside your own company, your own Odoo instance, your own projects).
 - **You may not** offer it to third parties as a hosted or managed service that provides them with access to a substantial set of its features -- that's what [Pantalytics](https://pantalytics.com) does, and what the license protects.
 - **You may not** remove license notices or circumvent license key functionality.
 
-Source-available, not OSI-open-source. See the full text in [LICENSE](LICENSE).
+The Elastic-licensed parts are source-available, not OSI-open-source. See [LICENSE](LICENSE), [LICENSE.MPL-2.0](LICENSE.MPL-2.0), and [NOTICE](NOTICE) for the full picture.
 
 ## For Odoo Implementation Partners
 
@@ -197,7 +202,7 @@ Interested? Contact [rutger@pantalytics.com](mailto:rutger@pantalytics.com) for 
 
 **odoo-mcp-pro** is built and maintained by [Pantalytics](https://pantalytics.com), an Odoo implementation partner based in Utrecht, Netherlands.
 
-Originally forked from [mcp-server-odoo](https://github.com/ivnvxd/mcp-server-odoo) by Andrey Ivanov (originally MPL-2.0).
+Originally forked from [mcp-server-odoo](https://github.com/ivnvxd/mcp-server-odoo) by Andrey Ivanov. The files that came from that project remain under the Mozilla Public License 2.0; see [NOTICE](NOTICE).
 
 ---
 

--- a/mcp_server_odoo/__init__.py
+++ b/mcp_server_odoo/__init__.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """MCP Server for Odoo - Model Context Protocol server for Odoo ERP systems."""
 
 __version__ = "2.3.1"

--- a/mcp_server_odoo/__init__.py
+++ b/mcp_server_odoo/__init__.py
@@ -6,7 +6,7 @@
 # This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """MCP Server for Odoo - Model Context Protocol server for Odoo ERP systems."""
 
-__version__ = "2.3.1"
+__version__ = "2.3.2"
 __author__ = "Andrey Ivanov"
 __license__ = "MPL-2.0"
 

--- a/mcp_server_odoo/__main__.py
+++ b/mcp_server_odoo/__main__.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Entry point for the mcp-server-odoo package.
 
 This module provides the command-line interface for running the

--- a/mcp_server_odoo/access_control.py
+++ b/mcp_server_odoo/access_control.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Access control for Odoo MCP Server.
 
 Uses Odoo's native check_access_rights to verify permissions.

--- a/mcp_server_odoo/config.py
+++ b/mcp_server_odoo/config.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Configuration management for Odoo MCP Server.
 
 This module handles loading and validation of environment variables

--- a/mcp_server_odoo/error_handler.py
+++ b/mcp_server_odoo/error_handler.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Central error handler and error utilities for Odoo MCP Server.
 
 This module provides:

--- a/mcp_server_odoo/error_handling.py
+++ b/mcp_server_odoo/error_handling.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Error handling and monitoring for Odoo MCP Server.
 
 This module provides a centralized error handling system with:

--- a/mcp_server_odoo/error_sanitizer.py
+++ b/mcp_server_odoo/error_sanitizer.py
@@ -1,10 +1,15 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Error message sanitizer for Odoo MCP Server.
 
 This module provides utilities to sanitize error messages before they are
 returned to users, removing internal implementation details while maintaining
 useful information for debugging.
 
-odoo-mcp-pro (c) Pantalytics B.V. -- ref:pnl-4d8b
 """
 
 import re

--- a/mcp_server_odoo/exceptions.py
+++ b/mcp_server_odoo/exceptions.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Shared exceptions for Odoo MCP server."""
 
 

--- a/mcp_server_odoo/formatters.py
+++ b/mcp_server_odoo/formatters.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Data formatters for LLM-friendly output.
 
 This module provides formatters that convert Odoo data into

--- a/mcp_server_odoo/logging_config.py
+++ b/mcp_server_odoo/logging_config.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Structured logging configuration for Odoo MCP Server.
 
 This module provides centralized logging setup with:

--- a/mcp_server_odoo/odoo_connection/__init__.py
+++ b/mcp_server_odoo/odoo_connection/__init__.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Odoo XML-RPC connection management.
 
 This package provides the OdooConnection class for managing connections

--- a/mcp_server_odoo/odoo_connection/auth.py
+++ b/mcp_server_odoo/odoo_connection/auth.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Authentication and database-access methods for OdooConnection.
 
 This module provides OdooConnectionAuthMixin, a plain mixin class that

--- a/mcp_server_odoo/odoo_connection/core.py
+++ b/mcp_server_odoo/odoo_connection/core.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Core OdooConnection class and connection lifecycle management.
 
 This module provides the OdooConnection class for managing connections

--- a/mcp_server_odoo/odoo_connection/orm.py
+++ b/mcp_server_odoo/odoo_connection/orm.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """ORM execution methods for OdooConnection.
 
 This module provides OdooConnectionOrmMixin, a plain mixin class that

--- a/mcp_server_odoo/performance.py
+++ b/mcp_server_odoo/performance.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Performance optimization and caching for Odoo MCP Server.
 
 This module provides performance optimizations including:

--- a/mcp_server_odoo/performance_cache.py
+++ b/mcp_server_odoo/performance_cache.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Caching and request optimization for Odoo MCP Server.
 
 This module provides the cache primitives used by the performance layer:

--- a/mcp_server_odoo/resources/__init__.py
+++ b/mcp_server_odoo/resources/__init__.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """MCP resource handlers for Odoo data access.
 
 This package implements MCP resources for accessing Odoo data through

--- a/mcp_server_odoo/resources/formatting.py
+++ b/mcp_server_odoo/resources/formatting.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Parsing and formatting helpers for Odoo MCP resources."""
 
 from __future__ import annotations

--- a/mcp_server_odoo/resources/handler.py
+++ b/mcp_server_odoo/resources/handler.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Resource handler class and registration for Odoo MCP resources."""
 
 from __future__ import annotations

--- a/mcp_server_odoo/resources/retrieval.py
+++ b/mcp_server_odoo/resources/retrieval.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Retrieval handlers for Odoo MCP resources."""
 
 from __future__ import annotations

--- a/mcp_server_odoo/schemas.py
+++ b/mcp_server_odoo/schemas.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Pydantic models for structured tool output.
 
 These models define the response schemas for MCP tools, enabling

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """MCP Server implementation for Odoo.
 
 This module provides the FastMCP server that exposes Odoo data

--- a/mcp_server_odoo/tools/__init__.py
+++ b/mcp_server_odoo/tools/__init__.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """MCP tool handlers for Odoo operations.
 
 This package implements MCP tools for performing operations on Odoo data.

--- a/mcp_server_odoo/tools/_common.py
+++ b/mcp_server_odoo/tools/_common.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Shared module-level constants and helpers for the tools package."""
 
 from __future__ import annotations

--- a/mcp_server_odoo/tools/crud.py
+++ b/mcp_server_odoo/tools/crud.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Single-record create/update/delete MCP tools."""
 
 from __future__ import annotations

--- a/mcp_server_odoo/tools/formatting.py
+++ b/mcp_server_odoo/tools/formatting.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Formatting and smart field selection helpers for Odoo tool handlers."""
 
 from __future__ import annotations

--- a/mcp_server_odoo/tools/handler.py
+++ b/mcp_server_odoo/tools/handler.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """MCP tool handlers for Odoo operations.
 
 This module implements MCP tools for performing operations on Odoo data.

--- a/mcp_server_odoo/tools/introspection.py
+++ b/mcp_server_odoo/tools/introspection.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Introspection MCP tools: list_models, list_resource_templates, server_info."""
 
 from __future__ import annotations

--- a/mcp_server_odoo/tools/query.py
+++ b/mcp_server_odoo/tools/query.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """Search and get-record MCP tools."""
 
 from __future__ import annotations

--- a/mcp_server_odoo/uri_schema.py
+++ b/mcp_server_odoo/uri_schema.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025 Andrey Ivanov <ivnv.xd@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Derived from mcp-server-odoo (https://github.com/ivnvxd/mcp-server-odoo).
+# This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """URI schema module for Odoo MCP Server.
 
 This module implements the URI schema for accessing Odoo data through MCP resources.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-server-odoo"
-version = "2.3.1"
+version = "2.3.2"
 description = "AI connector for Odoo ERP -- connect Claude, ChatGPT, and other AI tools to Odoo via MCP (Model Context Protocol)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Why

odoo-mcp-pro is a fork of Andrey Ivanov's [mcp-server-odoo](https://github.com/ivnvxd/mcp-server-odoo) (MPL-2.0). The repo declared **Elastic-2.0 throughout**, the **MPL-2.0 text was missing**, the MPL-covered files were **not marked**, and `error_sanitizer.py` had even picked up a Pantalytics-only copyright line. Andrey raised this (and followed up on 2026-07-10). Under MPL-2.0 the covered files and our modifications to them must stay available under MPL-2.0; only our genuinely new code is Elastic-2.0.

## What this does

Restores compliance **without changing how the project is distributed**:

- **`LICENSE.MPL-2.0`** - full MPL-2.0 text (from upstream).
- **`NOTICE`** - explains the dual licensing and lists every MPL-covered file.
- **SPDX `MPL-2.0` header** on the 30 files derived from the original project (attributing Andrey Ivanov + Pantalytics for modifications), including the `odoo_connection/`, `resources/`, and the derived `tools/` modules.
- **Removed** the stray `Pantalytics B.V.` copyright line from `error_sanitizer.py`.
- **README** license section rewritten to describe the split.

## The boundary (per-file by true origin)

Andrey's original tools (`search`/`query`, `crud`, `introspection`, `handler`, `_common`, `formatting`) -> **MPL-2.0**. New Pantalytics tools -> **stay Elastic-2.0** and are deliberately *not* marked MPL:

| Elastic (new Pantalytics) | reason |
|---|---|
| `tools/methods.py` | `execute_method` |
| `tools/wizards.py` | merge wizard |
| `tools/binary.py` | `set_binary_field` |
| `tools/bulk.py` | bulk import |
| `tools/messaging.py` | `post_message` |

Other new modules (`odoo_json2_*`, `detection*`, `skills`, `usage`, `version_detect`, `xmlrpc_transport`, `connection_protocol`, `odoo_knowledge`) also stay Elastic.

Each file's SPDX header is authoritative; `NOTICE` says so if the list and a header ever disagree.

## Verification

- `ruff check` + `ruff format --check` pass on the package.
- Package imports clean (`import mcp_server_odoo` OK).
- Only license metadata changed - no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)