### PR TITLE
fix: reported server version lagged (SERVER_VERSION stuck at 2.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 
 ## [Unreleased]
 
+## [2.3.3] - 2026-07-11
+
+### Fixed
+- The reported server version (shown in the admin footer, the `server_info`
+  tool, and `--version`) was stuck at 2.3.1 because `SERVER_VERSION` in
+  `server.py` was a separate constant that lagged the package version. All
+  version strings now read 2.3.3, and a test keeps `SERVER_VERSION`,
+  `__version__`, and `pyproject.toml` in lockstep so they cannot drift again.
+
 ## [2.3.2] - 2026-07-11
 
 ### Changed

--- a/mcp_server_odoo/__init__.py
+++ b/mcp_server_odoo/__init__.py
@@ -6,7 +6,7 @@
 # This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """MCP Server for Odoo - Model Context Protocol server for Odoo ERP systems."""
 
-__version__ = "2.3.2"
+__version__ = "2.3.3"
 __author__ = "Andrey Ivanov"
 __license__ = "MPL-2.0"
 

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -39,8 +39,9 @@ from .version_detect import detect_api_version
 # Set up logging
 logger = get_logger(__name__)
 
-# Server version — keep in sync with pyproject.toml
-SERVER_VERSION = "2.3.1"
+# Server version. Must match __version__ and pyproject.toml; enforced by
+# tests/test_version_consistency.py so it cannot silently drift.
+SERVER_VERSION = "2.3.3"
 GIT_COMMIT = os.environ.get("GIT_COMMIT", "unknown")
 _BUILD_ORIGIN = "pnl-mcp-7f3a"  # Pantalytics provenance tag
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-server-odoo"
-version = "2.3.2"
+version = "2.3.3"
 description = "AI connector for Odoo ERP -- connect Claude, ChatGPT, and other AI tools to Odoo via MCP (Model Context Protocol)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,23 @@
+"""The package version is declared in three places (``__version__``,
+``server.SERVER_VERSION``, and ``pyproject.toml``). They must stay in
+lockstep. A footer once showed a stale version because ``SERVER_VERSION``
+was bumped separately and lagged; these tests stop that from recurring.
+"""
+
+import pathlib
+import re
+
+from mcp_server_odoo import __version__
+from mcp_server_odoo.server import SERVER_VERSION
+
+
+def test_server_version_matches_package_version():
+    assert SERVER_VERSION == __version__
+
+
+def test_pyproject_version_matches_package_version():
+    root = pathlib.Path(__file__).resolve().parent.parent
+    text = (root / "pyproject.toml").read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    assert match, "no version found in pyproject.toml"
+    assert match.group(1) == __version__


### PR DESCRIPTION
## Why

We shipped v2.3.2 (the MPL-2.0 license work), but the admin footer, `server_info`, and `--version` kept showing **2.3.1**. Root cause: `SERVER_VERSION` in `server.py` is a separate constant that was not bumped alongside `__version__` / `pyproject.toml`. Classic version drift.

## What

- Bump `__version__`, `SERVER_VERSION`, and `pyproject.toml` to **2.3.3**.
- Add `tests/test_version_consistency.py` asserting the three stay in lockstep, so this cannot silently drift again.

Verified locally: `__version__ == SERVER_VERSION == 2.3.3`, new tests pass, ruff clean. License-only + version metadata, no runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)