### PR TITLE
feat(detection): measure edition and hosting as independent axes

### DIFF
--- a/mcp_server_odoo/__init__.py
+++ b/mcp_server_odoo/__init__.py
@@ -6,7 +6,7 @@
 # This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """MCP Server for Odoo - Model Context Protocol server for Odoo ERP systems."""
 
-__version__ = "2.3.3"
+__version__ = "2.4.0"
 __author__ = "Andrey Ivanov"
 __license__ = "MPL-2.0"
 

--- a/mcp_server_odoo/classification.py
+++ b/mcp_server_odoo/classification.py
@@ -1,0 +1,157 @@
+"""Edition and hosting: two independent axes, each decided by its own probes.
+
+These are separate questions about a server and they are answered separately.
+Deriving one from the other loses real information: an Odoo Online instance is
+also Enterprise, and collapsing that into a single "online" label throws the
+edition away. A Cloudflare-fronted Odoo still runs on some hosting; "behind a
+WAF" is a property of the network path, not a place the software runs.
+
+So: `decide_edition` and `decide_hosting` never read each other's output.
+`_taxonomy_conflicts` compares the two afterwards and reports pairs that cannot
+exist, which is a signal that a probe lied -- not an input to either decision.
+
+Each returns its own confidence, because the axes are not equally knowable for
+a given server: a v14 host can yield a confident hosting and an edition we can
+only guess from the version string.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Literal, Optional, Tuple
+
+from .detection_probes import ENTERPRISE_ASSET_MIN_VERSION, ProbeResult
+
+Hosting = Literal["online", "sh", "self_hosted", "unknown"]
+Edition = Literal["community", "enterprise"]
+Confidence = Literal["high", "medium", "low"]
+
+# Odoo Online and Odoo.sh both serve from here, so the domain alone never
+# separates them -- but it does rule out self-hosting, which is what makes the
+# absence of the Odoo.sh header readable.
+_ODOO_PLATFORM_DOMAIN = ".odoo.com"
+
+# Odoo.sh's proxy announces itself in the Server header. Measured present on
+# every Odoo.sh host we have and absent on every Odoo Online host we have.
+_ODOO_SH_SERVER_HEADER = "odoo.sh"
+
+# Odoo Online runs its rolling releases on saas~ versions. The stable ones
+# report a plain "19.0+e", so the absence of saas~ says nothing on its own.
+_ONLINE_VERSION_MARKER = "saas~"
+
+# Pairs that cannot exist: Odoo does not host Community on either platform.
+_IMPOSSIBLE = frozenset({("community", "online"), ("community", "sh")})
+
+_RANK: Dict[Confidence, int] = {"high": 3, "medium": 2, "low": 1}
+
+
+def is_odoo_platform_host(url: str) -> bool:
+    """True when the URL is on Odoo's own hosting domain (*.odoo.com)."""
+    host = url.split("://", 1)[-1].split("/", 1)[0].split(":", 1)[0].lower()
+    host = host.rstrip(".")
+    return host == "odoo.com" or host.endswith(_ODOO_PLATFORM_DOMAIN)
+
+
+def decide_edition(
+    by_name: Dict[str, ProbeResult],
+    major: Optional[int],
+    server_versions: List[str],
+) -> Tuple[Optional[Edition], Confidence, List[str]]:
+    """Community or Enterprise, from the strongest evidence available.
+
+    Ranked, because the signals are not equally trustworthy:
+
+    1. The web_enterprise asset answered. Community does not ship that addon,
+       so a 200 is proof. A 404 is proof of Community only once we know the
+       server is new enough to have the path AND that it serves addon static
+       files at all (the control asset) -- otherwise the probe abstains.
+    2. The "+e" version suffix. Weaker: it is absent whenever the version
+       probes are blocked, and it is the signal the asset probe exists to
+       replace. Kept as a second vote, and it is all we have on v14.
+    """
+    notes: List[str] = []
+    asset = by_name.get("enterprise_asset")
+    summary = asset.summary if asset else {}
+
+    if summary.get("serves_enterprise_asset"):
+        return "enterprise", "high", notes
+
+    asset_says_community = (
+        summary.get("serves_control_asset")
+        and major is not None
+        and major >= ENTERPRISE_ASSET_MIN_VERSION
+    )
+    if asset_says_community:
+        return "community", "high", notes
+
+    if asset and summary.get("serves_control_asset") and major is None:
+        notes.append("enterprise_asset_inconclusive: no major version to read it against")
+
+    suffix_edition: Optional[Edition] = None
+    if server_versions:
+        suffix_edition = "enterprise" if any("+e" in v for v in server_versions) else "community"
+
+    if suffix_edition is None:
+        return None, "low", notes
+
+    if asset and not summary.get("serves_control_asset"):
+        notes.append("enterprise_asset_unreadable: host does not serve the control asset")
+    return suffix_edition, "medium", notes
+
+
+def decide_hosting(
+    by_name: Dict[str, ProbeResult],
+    url: str,
+    server_versions: List[str],
+    is_odoo: bool,
+) -> Tuple[Hosting, Confidence, List[str]]:
+    """Odoo Online, Odoo.sh, or the customer's own infrastructure.
+
+    Deliberately says nothing about a WAF: `behind_waf` is reported alongside
+    this, not instead of it. A Cloudflare-fronted Odoo.sh is still Odoo.sh, and
+    overwriting the hosting with "behind_waf" is what made the column unable to
+    answer a hosting question.
+    """
+    notes: List[str] = []
+    headers = by_name.get("root_headers")
+    header_read = bool(headers and headers.ok)
+    server_hdr = ((headers.summary.get("server") if headers else "") or "").lower()
+
+    if _ODOO_SH_SERVER_HEADER in server_hdr:
+        return "sh", "high", notes
+    if any(_ONLINE_VERSION_MARKER in v for v in server_versions):
+        return "online", "high", notes
+    if not is_odoo:
+        return "unknown", "low", notes
+    if is_odoo_platform_host(url):
+        # Odoo hosts exactly two things here and Odoo.sh names itself in the
+        # Server header, so its absence points at Online. Only readable if the
+        # header probe actually answered: a timed-out probe is not an absent
+        # header, and treating it as one labels Odoo.sh hosts Online whenever
+        # the network hiccups.
+        if not header_read:
+            notes.append("hosting_undecidable: header probe failed, cannot read the sh marker")
+            return "unknown", "low", notes
+        # Medium, not high: reading an absence, so an Odoo.sh that ever stops
+        # sending the header would land here wrongly.
+        notes.append("hosting_from_absent_sh_header: *.odoo.com and no Odoo.sh marker")
+        return "online", "medium", notes
+    return "self_hosted", "high", notes
+
+
+def taxonomy_conflicts(edition: Optional[Edition], hosting: Hosting) -> List[str]:
+    """Report edition/hosting pairs that cannot exist. Never fixes them.
+
+    Both axes were measured independently, so an impossible pair means one of
+    the probes is wrong and we do not know which. Saying so is more useful than
+    silently dropping whichever one a rule happens to distrust.
+    """
+    if edition is None or hosting == "unknown":
+        return []
+    if (edition, hosting) in _IMPOSSIBLE:
+        return [f"impossible_taxonomy: edition={edition} on hosting={hosting}"]
+    return []
+
+
+def combined_confidence(edition_conf: Confidence, hosting_conf: Confidence) -> Confidence:
+    """The weaker of the two, for callers that want one number."""
+    return edition_conf if _RANK[edition_conf] <= _RANK[hosting_conf] else hosting_conf

--- a/mcp_server_odoo/detection.py
+++ b/mcp_server_odoo/detection.py
@@ -22,9 +22,15 @@ Probes implemented (see `detection_probes`):
   7. json2_unauth         — POST /json/2/res.users/context_get unauthenticated
                             (401 "Invalid apikey" → JSON/2 endpoint live → v19+)
   8. dns_cloudflare       — DNS A lookup + Cloudflare IP-range check
+  9. enterprise_asset     — GET a web_enterprise static file + a control file
+                            (Community does not ship web_enterprise)
 
 The aggregator turns this into a DetectionResult with api_version,
-server_version, hosting, edition, behind_waf, and a confidence label.
+server_version, hosting, edition, behind_waf, and confidence labels.
+
+Edition and hosting are separate questions and are answered separately, each
+from its own probes -- see `classification` for why deriving one from the other
+loses information. behind_waf is orthogonal to both.
 """
 
 from __future__ import annotations
@@ -35,11 +41,21 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
+from .classification import (  # noqa: F401  (types re-exported for callers)
+    Confidence,
+    Edition,
+    Hosting,
+    combined_confidence,
+    decide_edition,
+    decide_hosting,
+    taxonomy_conflicts,
+)
 from .detection_probes import (  # noqa: F401  (ProbeResult/_parse_major re-exported)
     PROBE_TIMEOUT_SECONDS,
     ProbeResult,
     _parse_major,
     _probe_dns_cloudflare,
+    _probe_enterprise_asset,
     _probe_json2_unauth,
     _probe_jsonrpc_version,
     _probe_root_headers,
@@ -55,9 +71,6 @@ JSON2_MIN_VERSION = 19
 
 
 ApiVersion = Literal["json2", "xmlrpc", "unknown"]
-Hosting = Literal["online", "sh", "self_hosted", "behind_waf", "unknown"]
-Edition = Literal["community", "enterprise"]
-Confidence = Literal["high", "medium", "low"]
 
 
 @dataclass
@@ -72,6 +85,11 @@ class DetectionResult:
     confidence: Confidence
     probes: List[ProbeResult]
     conflicts: List[str]
+    # Per axis, because they are not equally knowable on the same server: a v14
+    # yields a confident hosting and an edition we can only read off "+e".
+    # `confidence` stays the weaker of the two for callers wanting one number.
+    edition_confidence: Confidence = "low"
+    hosting_confidence: Confidence = "low"
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -80,7 +98,9 @@ class DetectionResult:
             "server_version": self.server_version,
             "major": self.major,
             "hosting": self.hosting,
+            "hosting_confidence": self.hosting_confidence,
             "edition": self.edition,
+            "edition_confidence": self.edition_confidence,
             "behind_waf": self.behind_waf,
             "confidence": self.confidence,
             "conflicts": self.conflicts,
@@ -97,6 +117,7 @@ _PROBES = (
     _probe_jsonrpc_version,
     _probe_json2_unauth,
     _probe_dns_cloudflare,
+    _probe_enterprise_asset,
 )
 
 
@@ -105,7 +126,7 @@ _PROBES = (
 # ---------------------------------------------------------------------------
 
 
-def _aggregate(probes: List[ProbeResult]) -> DetectionResult:
+def _aggregate(probes: List[ProbeResult], url: str) -> DetectionResult:
     """Rule-based fusion of probe outputs into a single conclusion.
 
     Voting strategy:
@@ -115,13 +136,10 @@ def _aggregate(probes: List[ProbeResult]) -> DetectionResult:
       Ties broken by preferring the highest version (forward-compat: we'd
       rather try json2 on a v18-v19 boundary instance).
     - api_version: json2 if json2_unauth said so OR majority major >= 19.
-    - hosting: Cloudflare server-header or CF IP range → behind_waf.
-      Server header "Odoo.sh" → sh. "saas~" version prefix → online.
-      Otherwise unknown.
-    - edition: "+e" suffix in any server_version → enterprise, else community
-      (only when at least one version probe succeeded; otherwise None).
-    - confidence: high if ≥3 probes contributed congruent signals;
-      medium with 2; low with 0 or 1.
+    - edition / hosting: see `classification`. Independent axes, each with its
+      own probes and its own confidence.
+    - behind_waf: Cloudflare server-header or CF IP range. Orthogonal to
+      hosting, never a substitute for it.
     """
     by_name = {p.name: p for p in probes}
     conflicts: List[str] = []
@@ -179,56 +197,28 @@ def _aggregate(probes: List[ProbeResult]) -> DetectionResult:
 
     server_version = server_versions[0] if server_versions else None
 
-    # Hosting
+    # A WAF sits on the network path; it is not a place the software runs. It
+    # is reported next to the hosting, never instead of it -- overwriting the
+    # hosting with "behind_waf" is what left the column unable to answer a
+    # hosting question for every Cloudflare-fronted customer.
     headers_probe = by_name.get("root_headers")
     server_hdr = (headers_probe.summary.get("server") if headers_probe else "") or ""
     dns_probe = by_name.get("dns_cloudflare")
-    is_cf_ip = bool(dns_probe and dns_probe.summary.get("is_cloudflare"))
-    is_cf_hdr = "cloudflare" in server_hdr.lower()
-    behind_waf = is_cf_ip or is_cf_hdr
-
-    hosting: Hosting
-    if behind_waf:
-        hosting = "behind_waf"
-    elif "Odoo.sh" in server_hdr:
-        hosting = "sh"
-    elif any("saas~" in sv for sv in server_versions):
-        hosting = "online"
-    elif is_odoo:
-        # nginx + non-saas version is ambiguous (could be Online or .sh).
-        # Don't claim certainty — see reference_odoo_taxonomy.md.
-        hosting = "self_hosted"
-    else:
-        hosting = "unknown"
-
-    # Edition (only meaningful when we have a version string)
-    edition: Optional[Edition] = None
-    if server_versions:
-        edition = "enterprise" if any("+e" in sv for sv in server_versions) else "community"
-
-    # Confidence: count probes that contributed to the conclusion
-    contributing = sum(
-        1
-        for p in probes
-        if p.ok
-        and p.name
-        in {
-            "xmlrpc_version",
-            "web_version",
-            "jsonrpc_version",
-            "json2_unauth",
-            "web_health",
-            "web_login",
-            "root_headers",
-            "dns_cloudflare",
-        }
+    behind_waf = bool(dns_probe and dns_probe.summary.get("is_cloudflare")) or (
+        "cloudflare" in server_hdr.lower()
     )
-    if contributing >= 3:
-        confidence: Confidence = "high"
-    elif contributing == 2:
-        confidence = "medium"
-    else:
-        confidence = "low"
+
+    # Two axes, decided from their own probes and blind to each other. The
+    # taxonomy is checked afterwards and only reports contradictions: both
+    # answers were measured, so an impossible pair means a probe lied and we
+    # cannot tell which.
+    edition, edition_confidence, edition_notes = decide_edition(by_name, major, server_versions)
+    hosting, hosting_confidence, hosting_notes = decide_hosting(
+        by_name, url, server_versions, is_odoo
+    )
+    conflicts.extend(edition_notes)
+    conflicts.extend(hosting_notes)
+    conflicts.extend(taxonomy_conflicts(edition, hosting))
 
     return DetectionResult(
         is_odoo=is_odoo,
@@ -238,7 +228,9 @@ def _aggregate(probes: List[ProbeResult]) -> DetectionResult:
         hosting=hosting,
         edition=edition,
         behind_waf=behind_waf,
-        confidence=confidence,
+        confidence=combined_confidence(edition_confidence, hosting_confidence),
+        edition_confidence=edition_confidence,
+        hosting_confidence=hosting_confidence,
         probes=list(probes),
         conflicts=conflicts,
     )
@@ -256,15 +248,17 @@ async def detect_odoo(url: str, timeout: int = PROBE_TIMEOUT_SECONDS) -> Detecti
     with ThreadPoolExecutor(max_workers=len(_PROBES)) as pool:
         tasks = [loop.run_in_executor(pool, p, url, timeout) for p in _PROBES]
         probes: List[ProbeResult] = list(await asyncio.gather(*tasks))
-    result = _aggregate(probes)
+    result = _aggregate(probes, url)
     logger.info(
-        "Detected %s: api=%s major=%s hosting=%s waf=%s confidence=%s (probes_ok=%d/%d)",
+        "Detected %s: api=%s major=%s hosting=%s(%s) edition=%s(%s) waf=%s (probes_ok=%d/%d)",
         url,
         result.api_version,
         result.major,
         result.hosting,
+        result.hosting_confidence,
+        result.edition,
+        result.edition_confidence,
         result.behind_waf,
-        result.confidence,
         sum(1 for p in probes if p.ok),
         len(probes),
     )

--- a/mcp_server_odoo/detection_probes.py
+++ b/mcp_server_odoo/detection_probes.py
@@ -310,6 +310,76 @@ def _probe_json2_unauth(url: str, timeout: int) -> ProbeResult:
     )
 
 
+# web_enterprise ships only with Enterprise, and Odoo serves addon static files
+# without auth, so fetching one answers the edition question directly instead of
+# reading it off the version string. Two paths because the layout moved: both
+# exist from v15 (measured on v15/v16/v17/v18/v19, across Online, Odoo.sh and
+# self-hosted), and neither exists on v14 -- there the probe abstains rather than
+# call a v14 Enterprise "community".
+_ENTERPRISE_ASSETS = (
+    "/web_enterprise/static/src/main.js",
+    "/web_enterprise/static/src/webclient/webclient.js",
+)
+
+# Control: ships with every edition and every version we support. Without it a
+# 404 on the enterprise assets is unreadable -- it could mean Community, or it
+# could mean this host does not serve addon static files the way we assume
+# (measured: a v14 returns 404 for /web/static/src/main.js but 200 for jquery).
+_EDITION_CONTROL_ASSETS = (
+    "/web/static/lib/jquery/jquery.js",
+    "/web/static/src/main.js",
+)
+
+# The enterprise asset paths only exist from this major on. Below it, a 404
+# proves nothing about the edition.
+ENTERPRISE_ASSET_MIN_VERSION = 15
+
+
+def _asset_status(url: str, path: str, timeout: int) -> Optional[int]:
+    """GET an addon static file, no redirects. None when the request failed."""
+    try:
+        return cffi_requests.get(
+            f"{url}{path}",
+            impersonate=_IMPERSONATE,
+            timeout=timeout,
+            allow_redirects=False,
+        ).status_code
+    except Exception:
+        return None
+
+
+@_timed
+def _probe_enterprise_asset(url: str, timeout: int) -> ProbeResult:
+    """Fetch a web_enterprise static file, plus a control that both editions ship.
+
+    Reports what it saw and lets the aggregator conclude: the probe cannot see
+    the major version, and a 404 only means Community from v15 on. `ok` means
+    the probe produced a readable answer, not that the server is Enterprise.
+    """
+    t0 = perf_counter()
+    enterprise_hits = {p: _asset_status(url, p, timeout) for p in _ENTERPRISE_ASSETS}
+    serves_enterprise = any(s == 200 for s in enterprise_hits.values())
+
+    control_hits: Dict[str, Optional[int]] = {}
+    if not serves_enterprise:
+        # Only needed to read a negative; skip the extra round trips otherwise.
+        for p in _EDITION_CONTROL_ASSETS:
+            control_hits[p] = _asset_status(url, p, timeout)
+    serves_control = any(s == 200 for s in control_hits.values())
+
+    return ProbeResult(
+        name="enterprise_asset",
+        ok=serves_enterprise or serves_control,
+        latency_ms=int((perf_counter() - t0) * 1000),
+        summary={
+            "serves_enterprise_asset": serves_enterprise,
+            "serves_control_asset": serves_control,
+            "enterprise_paths": {p: s for p, s in enterprise_hits.items()},
+            "control_paths": {p: s for p, s in control_hits.items()},
+        },
+    )
+
+
 @_timed
 def _probe_dns_cloudflare(url: str, timeout: int) -> ProbeResult:
     """Resolve the hostname and check if the IP falls in Cloudflare's ranges."""

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -41,7 +41,7 @@ logger = get_logger(__name__)
 
 # Server version. Must match __version__ and pyproject.toml; enforced by
 # tests/test_version_consistency.py so it cannot silently drift.
-SERVER_VERSION = "2.3.3"
+SERVER_VERSION = "2.4.0"
 GIT_COMMIT = os.environ.get("GIT_COMMIT", "unknown")
 _BUILD_ORIGIN = "pnl-mcp-7f3a"  # Pantalytics provenance tag
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-server-odoo"
-version = "2.3.3"
+version = "2.4.0"
 description = "AI connector for Odoo ERP -- connect Claude, ChatGPT, and other AI tools to Odoo via MCP (Model Context Protocol)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -1,0 +1,212 @@
+"""Edition and hosting are decided independently, each from its own probes.
+
+Every case here is drawn from a real server we measured; the docstrings name it
+so a future reader can re-check the claim instead of trusting the fixture.
+"""
+
+from mcp_server_odoo.classification import (
+    combined_confidence,
+    decide_edition,
+    decide_hosting,
+    taxonomy_conflicts,
+)
+from mcp_server_odoo.detection_probes import ProbeResult
+
+PLATFORM_URL = "https://acme.odoo.com"
+SELF_HOSTED_URL = "https://odoo.acme.example"
+
+
+def _ok(name: str, **summary) -> ProbeResult:
+    return ProbeResult(name=name, ok=True, latency_ms=10, summary=summary)
+
+
+def _fail(name: str) -> ProbeResult:
+    return ProbeResult(name=name, ok=False, latency_ms=10)
+
+
+def _by_name(*probes: ProbeResult):
+    return {p.name: p for p in probes}
+
+
+class TestEdition:
+    def test_enterprise_asset_beats_a_missing_version(self):
+        """The whole point of the asset probe: it answers when the version
+        string does not. Measured on osher1624 (v16) and mole.odoo.com (v15)."""
+        edition, conf, _ = decide_edition(
+            _by_name(_ok("enterprise_asset", serves_enterprise_asset=True)),
+            major=16,
+            server_versions=[],
+        )
+        assert edition == "enterprise"
+        assert conf == "high"
+
+    def test_no_enterprise_asset_with_control_means_community(self):
+        """bean-forge (19.0): enterprise paths 404, control 200 -> Community."""
+        edition, conf, _ = decide_edition(
+            _by_name(
+                _ok(
+                    "enterprise_asset",
+                    serves_enterprise_asset=False,
+                    serves_control_asset=True,
+                )
+            ),
+            major=19,
+            server_versions=["19.0"],
+        )
+        assert edition == "community"
+        assert conf == "high"
+
+    def test_v14_enterprise_is_not_called_community(self):
+        """odoo.livelinkmotor.net (14.0+e) serves the control asset but 404s on
+        every web_enterprise path -- those only exist from v15. Reading that 404
+        as Community would be a confident lie, so the asset probe abstains and
+        the version suffix answers."""
+        edition, conf, _ = decide_edition(
+            _by_name(
+                _ok(
+                    "enterprise_asset",
+                    serves_enterprise_asset=False,
+                    serves_control_asset=True,
+                )
+            ),
+            major=14,
+            server_versions=["14.0+e"],
+        )
+        assert edition == "enterprise"
+        assert conf == "medium"
+
+    def test_unreadable_control_falls_back_to_the_suffix(self):
+        """support.proautomationservices.com (14.0): 404s the control too, so
+        the host does not serve addon static files the way we assume."""
+        probes = _by_name(
+            _ok(
+                "enterprise_asset",
+                serves_enterprise_asset=False,
+                serves_control_asset=False,
+            )
+        )
+        edition, conf, notes = decide_edition(probes, 14, ["14.0"])
+        assert edition == "community"
+        assert conf == "medium"
+        assert any("unreadable" in n for n in notes)
+
+    def test_nothing_to_go_on_returns_none(self):
+        edition, conf, _ = decide_edition(_by_name(_fail("enterprise_asset")), None, [])
+        assert edition is None
+        assert conf == "low"
+
+    def test_hosting_never_leaks_into_the_edition(self):
+        """Odoo.sh only runs Enterprise, but that is an inference about the
+        product, not a measurement of this server. The edition decision must not
+        read the Server header; if the edition probes stay silent, it says so."""
+        probes = _by_name(_ok("root_headers", server="Odoo.sh"))
+        edition, conf, _ = decide_edition(probes, major=17, server_versions=[])
+        assert edition is None
+        assert conf == "low"
+
+
+class TestHosting:
+    def test_odoo_sh_server_header(self):
+        """pantalytics.odoo.com, georgiesceramic.odoo.com, officeplus."""
+        hosting, conf, _ = decide_hosting(
+            _by_name(_ok("root_headers", server="Odoo.sh")),
+            PLATFORM_URL,
+            ["19.0+e"],
+            is_odoo=True,
+        )
+        assert hosting == "sh"
+        assert conf == "high"
+
+    def test_saas_version_means_online(self):
+        """altaocto.odoo.com, bd-rollers.odoo.com."""
+        hosting, conf, _ = decide_hosting(
+            _by_name(_ok("root_headers", server="nginx")),
+            PLATFORM_URL,
+            ["saas~19.2+e"],
+            is_odoo=True,
+        )
+        assert hosting == "online"
+        assert conf == "high"
+
+    def test_platform_host_without_sh_header_is_online_at_medium(self):
+        """opus-digital.odoo.com: 19.0+e, nginx, no saas~. Odoo hosts only
+        Online and Odoo.sh on *.odoo.com and Odoo.sh names itself, so this is
+        Online -- but it is read off an absence, hence medium."""
+        hosting, conf, notes = decide_hosting(
+            _by_name(_ok("root_headers", server="nginx")),
+            PLATFORM_URL,
+            ["19.0+e"],
+            is_odoo=True,
+        )
+        assert hosting == "online"
+        assert conf == "medium"
+        assert any("absent_sh_header" in n for n in notes)
+
+    def test_failed_header_probe_is_not_an_absent_header(self):
+        """A timed-out probe must not be read as "no Odoo.sh marker". This
+        mislabelled georgiesceramic (Odoo.sh) as Online when its header probe
+        timed out under load."""
+        hosting, conf, notes = decide_hosting(
+            _by_name(_fail("root_headers")),
+            PLATFORM_URL,
+            ["17.0+e"],
+            is_odoo=True,
+        )
+        assert hosting == "unknown"
+        assert conf == "low"
+        assert any("undecidable" in n for n in notes)
+
+    def test_self_hosted_off_platform(self):
+        """juffermans.cloudpepper.site, bean-forge.cloudpepper.site."""
+        hosting, conf, _ = decide_hosting(
+            _by_name(_ok("root_headers", server="nginx/1.30.3")),
+            SELF_HOSTED_URL,
+            ["19.0"],
+            is_odoo=True,
+        )
+        assert hosting == "self_hosted"
+        assert conf == "high"
+
+    def test_not_an_odoo_is_unknown(self):
+        hosting, conf, _ = decide_hosting(
+            _by_name(_ok("root_headers", server="Apache")),
+            SELF_HOSTED_URL,
+            [],
+            is_odoo=False,
+        )
+        assert hosting == "unknown"
+        assert conf == "low"
+
+    def test_edition_never_leaks_into_the_hosting(self):
+        """Community rules out Odoo's platforms, but hosting is measured, not
+        inferred from the edition. Same probes, same answer, whatever the
+        edition turns out to be."""
+        probes = _by_name(_ok("root_headers", server="Odoo.sh"))
+        for versions in (["19.0+e"], ["19.0"], []):
+            hosting, conf, _ = decide_hosting(probes, PLATFORM_URL, versions, True)
+            assert (hosting, conf) == ("sh", "high")
+
+
+class TestTaxonomy:
+    def test_impossible_pair_is_reported_not_fixed(self):
+        """Both axes were measured, so we cannot tell which probe lied. Saying
+        so beats silently dropping whichever one a rule distrusts."""
+        assert taxonomy_conflicts("community", "sh")
+        assert taxonomy_conflicts("community", "online")
+
+    def test_real_pairs_are_quiet(self):
+        assert taxonomy_conflicts("enterprise", "sh") == []
+        assert taxonomy_conflicts("enterprise", "online") == []
+        assert taxonomy_conflicts("enterprise", "self_hosted") == []
+        assert taxonomy_conflicts("community", "self_hosted") == []
+
+    def test_unknowns_are_never_conflicts(self):
+        assert taxonomy_conflicts(None, "sh") == []
+        assert taxonomy_conflicts("community", "unknown") == []
+
+
+class TestCombinedConfidence:
+    def test_takes_the_weaker_axis(self):
+        assert combined_confidence("high", "medium") == "medium"
+        assert combined_confidence("low", "high") == "low"
+        assert combined_confidence("high", "high") == "high"

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -22,6 +22,13 @@ def _fail(name: str, status_code=None) -> ProbeResult:
     return ProbeResult(name=name, ok=False, latency_ms=100, status_code=status_code)
 
 
+# The aggregator reads the URL: *.odoo.com rules out self-hosting, which is what
+# makes an absent Odoo.sh header point at Online. Default to a host outside
+# Odoo's platform so a test only opts into that logic by passing an odoo.com URL.
+SELF_HOSTED_URL = "https://odoo.acme.example"
+PLATFORM_URL = "https://acme.odoo.com"
+
+
 class TestAggregator:
     """The aggregator is a pure function over ProbeResult lists."""
 
@@ -33,14 +40,17 @@ class TestAggregator:
             _ok("json2_unauth", supports_json2=True),
             _ok("root_headers", server="nginx"),
             _ok("dns_cloudflare", ip="1.2.3.4", is_cloudflare=False),
+            _ok("enterprise_asset", serves_enterprise_asset=True),
         ]
-        r = _aggregate(probes)
+        r = _aggregate(probes, PLATFORM_URL)
         assert r.is_odoo
         assert r.api_version == "json2"
         assert r.major == 19
         assert r.server_version == "saas~19.2+e"
         assert r.hosting == "online"
+        assert r.hosting_confidence == "high"
         assert r.edition == "enterprise"
+        assert r.edition_confidence == "high"
         assert not r.behind_waf
         assert r.confidence == "high"
         assert r.conflicts == []
@@ -53,22 +63,29 @@ class TestAggregator:
             _ok("root_headers", server="Werkzeug"),
             _ok("dns_cloudflare", is_cloudflare=False),
         ]
-        r = _aggregate(probes)
+        r = _aggregate(probes, SELF_HOSTED_URL)
         assert r.api_version == "xmlrpc"
         assert r.major == 18
         assert r.hosting == "self_hosted"
         assert r.edition == "enterprise"
 
-    def test_behind_cloudflare_by_dns(self):
+    def test_behind_cloudflare_keeps_the_real_hosting(self):
+        """A WAF sits on the network path; it is not where the software runs.
+
+        Reporting hosting='behind_waf' overwrote the answer we already had: this
+        instance says saas~, so it is Odoo Online whether or not Cloudflare
+        fronts it. behind_waf rides alongside as its own fact.
+        """
         probes = [
             _ok("web_version", server_version="saas~19.2+e", major=19),
             _ok("json2_unauth", supports_json2=True),
             _ok("dns_cloudflare", ip="104.21.13.7", is_cloudflare=True),
             _ok("root_headers", server="cloudflare"),
         ]
-        r = _aggregate(probes)
+        r = _aggregate(probes, PLATFORM_URL)
         assert r.behind_waf
-        assert r.hosting == "behind_waf"
+        assert r.hosting == "online"
+        assert r.hosting_confidence == "high"
         assert r.api_version == "json2"
 
     def test_odoo_sh_via_server_header(self):
@@ -77,7 +94,7 @@ class TestAggregator:
             _ok("root_headers", server="Odoo.sh"),
             _ok("dns_cloudflare", is_cloudflare=False),
         ]
-        r = _aggregate(probes)
+        r = _aggregate(probes, SELF_HOSTED_URL)
         assert r.hosting == "sh"
 
     def test_json2_endpoint_overrides_version_vote(self):
@@ -88,7 +105,7 @@ class TestAggregator:
             _ok("json2_unauth", supports_json2=True),
             _ok("root_headers", server="nginx"),
         ]
-        r = _aggregate(probes)
+        r = _aggregate(probes, SELF_HOSTED_URL)
         assert r.api_version == "json2"
         assert r.major >= 19
         assert any("json2_endpoint_live" in c for c in r.conflicts)
@@ -99,7 +116,7 @@ class TestAggregator:
             _ok("web_version", server_version="18.0+e", major=18),
             _fail("json2_unauth"),
         ]
-        r = _aggregate(probes)
+        r = _aggregate(probes, SELF_HOSTED_URL)
         # Tie broken by max
         assert r.major == 19
         assert any("disagreement" in c for c in r.conflicts)
@@ -115,7 +132,7 @@ class TestAggregator:
             _fail("root_headers"),
             _fail("dns_cloudflare"),
         ]
-        r = _aggregate(probes)
+        r = _aggregate(probes, SELF_HOSTED_URL)
         assert not r.is_odoo
         assert r.api_version == "unknown"
         assert r.major is None
@@ -130,7 +147,7 @@ class TestAggregator:
             _ok("dns_cloudflare", ip="1.2.3.4", is_cloudflare=False),
             _ok("root_headers", server="Apache"),
         ]
-        r = _aggregate(probes)
+        r = _aggregate(probes, SELF_HOSTED_URL)
         assert not r.is_odoo
         assert r.api_version == "unknown"
 
@@ -141,12 +158,12 @@ class TestAggregator:
             _fail("web_version"),
             _fail("json2_unauth"),
         ]
-        r = _aggregate(probes)
+        r = _aggregate(probes, SELF_HOSTED_URL)
         assert r.confidence == "medium"
 
     def test_to_dict_round_trips(self):
         probes = [_ok("xmlrpc_version", server_version="19.0+e", major=19)]
-        r = _aggregate(probes)
+        r = _aggregate(probes, SELF_HOSTED_URL)
         d = r.to_dict()
         # major=19 -> json2 even without a live json2 probe; the json2
         # endpoint becomes the override when present, not a requirement.


### PR DESCRIPTION
Edition and hosting are different questions about a server. They were tangled together, and both were read off signals that do not carry them.

## What was wrong

| | before | why it is wrong |
|---|---|---|
| **edition** | `"+e" in version_string` | the only vote; gone whenever the version probes are blocked |
| **hosting** | `behind_waf` overwrote it | a Cloudflare-fronted Odoo Online is still Odoo Online |
| **hosting** | `*.odoo.com` + no `saas~` -> `self_hosted` | Odoo hosts those; they are never self-hosted |

## What this does

Two shotguns that never read each other's output, each with its own confidence, plus a taxonomy check that only **reports** impossible pairs. Both answers were measured, so a contradiction means a probe lied and we cannot tell which one -- saying so beats silently dropping whichever one a rule distrusts.

`behind_waf` stays a fact of its own, reported next to the hosting rather than instead of it.

## The new edition probe

Community does not ship `web_enterprise`, and Odoo serves addon static files without auth, so fetching one answers the edition directly instead of reading a suffix. All of this is measured, not assumed:

- **200** on v15-v19 Enterprise, across Online, Odoo.sh and self-hosted.
- **404 + a working control asset** on Community.
- **v14 Enterprise 404s every `web_enterprise` path** (they arrived in v15). The probe abstains below v15 rather than call a v14 Enterprise "community", and the version suffix answers instead at medium confidence.
- The **control asset** exists because a v14 also 404s `/web/static/src/main.js`. A 404 is only readable once we know the host serves addon static files at all. `/web/static/lib/jquery/jquery.js` returns 200 on v14 through v19, both editions.

## Hosting signals

- `Server: Odoo.sh` -> sh. Present on **4/4** known Odoo.sh hosts, absent on **14/14** known Online hosts.
- `saas~` in the version -> online.
- `*.odoo.com` with neither -> online at **medium**, because it reads an absence. Odoo hosts exactly two things there and Odoo.sh names itself. This case is ~46% of our `.odoo.com` instances, so "unknown" would not be useful.
- Only inferred when the header probe **actually answered**. A timed-out probe is not an absent header -- that mislabelled a real Odoo.sh host as Online under load, which is how the guard got written.

## Verification

Against 11 production servers with known truth (Odoo.sh, Online, self-hosted; v14 through v19; both editions): **11/11 correct**, with the confidence landing where it should -- `medium` on the two v14 hosts and on the absence-inferred Online.

569 unit tests pass; new `tests/test_classification.py` pins each case to the real server it came from.

## Note for the admin repo

`mcp-server-odoo-admin` pins this package at `v2.3.3`, so it cannot consume any of this until a release is cut. Nothing in the admin repo should import `classification` before then.