### PR TITLE
security: don't follow HTTP redirects on detection probes + JSON/2 session

### DIFF
--- a/mcp_server_odoo/detection_probes.py
+++ b/mcp_server_odoo/detection_probes.py
@@ -127,7 +127,7 @@ def _probe_web_version(url: str, timeout: int) -> ProbeResult:
         f"{url}/web/version",
         impersonate=_IMPERSONATE,
         timeout=timeout,
-        allow_redirects=True,
+        allow_redirects=False,  # SSRF: never follow a redirect to an unchecked host
     )
     summary: Dict[str, Any] = {}
     if r.status_code == 200:
@@ -159,7 +159,7 @@ def _probe_web_health(url: str, timeout: int) -> ProbeResult:
         f"{url}/web/health",
         impersonate=_IMPERSONATE,
         timeout=timeout,
-        allow_redirects=True,
+        allow_redirects=False,  # SSRF: never follow a redirect to an unchecked host
     )
     text = (r.text or "")[:300]
     is_odoo_health = r.status_code == 200 and "pass" in text
@@ -180,7 +180,7 @@ def _probe_web_login(url: str, timeout: int) -> ProbeResult:
         f"{url}/web/login",
         impersonate=_IMPERSONATE,
         timeout=timeout,
-        allow_redirects=True,
+        allow_redirects=False,  # SSRF: never follow a redirect to an unchecked host
     )
     text_low = (r.text or "").lower()
     has_o_login = "o_login" in text_low or "o_database_list" in text_low
@@ -213,7 +213,7 @@ def _probe_root_headers(url: str, timeout: int) -> ProbeResult:
         url,
         impersonate=_IMPERSONATE,
         timeout=timeout,
-        allow_redirects=True,
+        allow_redirects=False,  # SSRF: never follow a redirect to an unchecked host
     )
     server = ""
     try:
@@ -243,7 +243,7 @@ def _probe_jsonrpc_version(url: str, timeout: int) -> ProbeResult:
         json=body,
         impersonate=_IMPERSONATE,
         timeout=timeout,
-        allow_redirects=True,
+        allow_redirects=False,  # SSRF: never follow a redirect to an unchecked host
     )
     summary: Dict[str, Any] = {}
     if r.status_code == 200:
@@ -282,7 +282,7 @@ def _probe_json2_unauth(url: str, timeout: int) -> ProbeResult:
         json={},
         impersonate=_IMPERSONATE,
         timeout=timeout,
-        allow_redirects=True,
+        allow_redirects=False,  # SSRF: never follow a redirect to an unchecked host
     )
     summary: Dict[str, Any] = {"status_code": r.status_code}
     supports_json2 = False

--- a/mcp_server_odoo/odoo_json2_connection.py
+++ b/mcp_server_odoo/odoo_json2_connection.py
@@ -187,7 +187,11 @@ class OdooJSON2Connection(Json2OrmMixin):
             self._client = cffi_requests.Session(
                 impersonate="chrome",
                 timeout=self.timeout,
-                allow_redirects=True,
+                # SSRF: the host was SSRF-checked before we got here, but a
+                # redirect would re-dial an unchecked target (e.g. cloud
+                # metadata). Don't follow them; a real Odoo API base does not
+                # redirect its /json/2 calls.
+                allow_redirects=False,
             )
 
             # Test connection by fetching server version

--- a/tests/test_detection_probes_ssrf.py
+++ b/tests/test_detection_probes_ssrf.py
@@ -1,0 +1,46 @@
+"""SSRF: detection probes must not follow redirects.
+
+The setup-time probes SSRF-check only the submitted host. If a probe followed a
+redirect, a benign public host could 302 the probe to an internal/metadata
+address (e.g. 169.254.169.254) that was never checked, and the response would be
+bucketed back into detection evidence (an exfil channel). Every probe HTTP call
+must therefore pass allow_redirects=False.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from mcp_server_odoo import detection_probes as dp
+
+_HTTP_PROBES = (
+    dp._probe_web_version,
+    dp._probe_web_health,
+    dp._probe_web_login,
+    dp._probe_root_headers,
+    dp._probe_jsonrpc_version,
+    dp._probe_json2_unauth,
+)
+
+
+def test_probes_never_follow_redirects():
+    fake = MagicMock()
+    resp = MagicMock()
+    resp.status_code = 500  # force the non-2xx branch; we only check the call
+    fake.get.return_value = resp
+    fake.post.return_value = resp
+    fake.request.return_value = resp
+
+    with patch.object(dp, "cffi_requests", fake):
+        for probe in _HTTP_PROBES:
+            try:
+                probe("https://acme.example.com", 5)
+            except Exception:
+                # Parsing the fake response may raise; we only assert how the
+                # outbound call was made, which already happened by then.
+                pass
+
+    calls = fake.get.call_args_list + fake.post.call_args_list + fake.request.call_args_list
+    assert calls, "no probe issued an HTTP call"
+    for c in calls:
+        assert c.kwargs.get("allow_redirects") is False, (
+            f"probe call {c} must not follow redirects (SSRF)"
+        )


### PR DESCRIPTION
The setup-time detection probes and the JSON/2 connection session ran with
`allow_redirects=True`. The SSRF guard validates only the host that was
submitted, so a benign public host could 302 the probe or connection to an
unchecked internal or cloud-metadata address (169.254.169.254), and the
response would be bucketed back into detection evidence. That is a live
SSRF/exfil path reachable from the authenticated setup flow.

Every probe now uses `allow_redirects=False`, matching `resolve_database`,
which already did. A real Odoo API base does not redirect its probe, version
or JSON/2 calls, so nothing legitimate breaks.

Tests assert `allow_redirects=False` on every detection probe HTTP call.

Found by a security pass in the admin repo on 2026-06-29; the branch sat
unpushed until now, rebased onto current main. The remaining DNS-rebinding
TOCTOU on the same paths needs an infra fix (pin the resolved IP, or an
egress policy) and is tracked separately.

Note: 16 tests fail on this branch and the same 16 fail on `main` (they need
a live Odoo), so they are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)