### PR TITLE
build: pin ruff below 0.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,11 @@ dev = [
     "pytest-asyncio>=1.4.0",
     "pytest-cov>=7.1.0",
     "ty>=0.0.49",
-    "ruff>=0.15.16",
+    # Upper bound on purpose: ruff 0.16 widens the default rule set and starts
+    # formatting python blocks inside markdown, so it fails the lint job on files
+    # a PR never touched. CI installs whatever this range allows. Raise the bound
+    # deliberately, with the cleanup in the same change.
+    "ruff>=0.15.16,<0.16",
     "requests>=2.34.2",
 ]
 


### PR DESCRIPTION
Ruff 0.16 shipped today. It widens the default rule set and starts formatting
python code blocks inside markdown, so `ruff format --check .` now fails on
`skills/odoo-advisor/SKILL.md` and other docs that no PR has touched. The dev
extra allowed any ruff, so CI picked it up on its own and every open PR in this
repo went red for that reason alone.

This bounds the dev extra to `<0.16`, which is what everyone runs locally.
Adopting 0.16 is worth doing, but as its own change with the reformatting in it,
not as a surprise in the middle of unrelated PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)