### PR TITLE
fix(post_message): probe the outlook field with the signature that exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 
 ## [Unreleased]
 
+### Fixed
+- `post_message` no longer raises a `TypeError` on every call. The probe that
+  checks whether `mail.message` carries `x_microsoft_message_id` passed an
+  `allfields` keyword that no connection implementation accepts, then caught
+  the resulting `TypeError` and retried with the supported signature. The post
+  itself still succeeded, so nobody noticed, but anything watching the
+  connection recorded a failed Odoo call. The probe now uses the declared
+  signature directly.
+
 ## [2.3.3] - 2026-07-11
 
 ### Fixed

--- a/mcp_server_odoo/tools/messaging.py
+++ b/mcp_server_odoo/tools/messaging.py
@@ -207,14 +207,6 @@ class MessagingToolsMixin:
                     outlook_field = "x_microsoft_message_id"
                     try:
                         available = await run_blocking(
-                            connection,
-                            connection.fields_get,
-                            "mail.message",
-                            [outlook_field],
-                            allfields=False,
-                        )
-                    except TypeError:
-                        available = await run_blocking(
                             connection, connection.fields_get, "mail.message", [outlook_field]
                         )
                     except Exception:

--- a/tests/test_post_message.py
+++ b/tests/test_post_message.py
@@ -154,6 +154,29 @@ class TestPostMessageUnit:
         assert result["outlook_pro_message_id"] == "<AAMkAG...>"
 
     @pytest.mark.asyncio
+    async def test_outlook_probe_uses_the_supported_signature(self, handler, mock_connection):
+        """The probe must call fields_get the way the connection protocol
+        declares it: fields_get(model, attributes). It used to pass an
+        allfields kwarg first and catch the resulting TypeError as a fallback,
+        which no implementation ever accepted, so every post_message raised a
+        TypeError that callers then swallowed. Anything watching the connection
+        (SaaS failure telemetry) recorded that as a failed Odoo call.
+        """
+        mock_connection.read.side_effect = [
+            [{"id": 7}],
+            [{"subtype_id": [1, "Discussions"], "attachment_ids": []}],
+        ]
+        mock_connection.fields_get.return_value = {}
+        mock_connection.call_method.return_value = 42
+        mock_connection.search_read.return_value = []
+
+        await handler._handle_post_message_tool(model="res.partner", record_id=7, body="<p>hi</p>")
+
+        probe = mock_connection.fields_get.call_args
+        assert probe.args == ("mail.message", ["x_microsoft_message_id"])
+        assert probe.kwargs == {}
+
+    @pytest.mark.asyncio
     async def test_record_not_found(self, handler, mock_connection):
         mock_connection.read.return_value = []
         with pytest.raises(ValidationError, match="Record not found"):


### PR DESCRIPTION
## What

`post_message` probes whether `mail.message` carries `x_microsoft_message_id` (it only exists when `pan_outlook_pro` is installed). That probe called `fields_get` with an `allfields=False` keyword, caught the resulting `TypeError`, and retried with the plain signature.

No implementation accepts `allfields`. All three declare `fields_get(self, model, attributes=None)` (`connection_protocol.py:55`, `odoo_connection/orm.py:187`, `odoo_json2_orm.py:88`), so the first attempt raised every single time and the fallback did the real work.

## Why it matters

The post still succeeded, so nothing showed up in the tool's output. But the failed RPC was real, and the hosted side records Odoo call failures at the connection: in the first two days of that telemetry it logged 87 `TypeError` failures on `mail.message` / `fields_get` against 127 successful `post_message` calls. That is 26% of all recorded Odoo failures, and it also fed the failure corpus that turns recurring patterns into skills.

## How

Dropped the first attempt. The `except Exception: available = {}` fallback stays, so a genuine failure to read `mail.message` still degrades to an empty field map rather than turning a successful post into a reported failure.

## Tests

`tests/test_post_message.py` gains a regression test asserting the probe calls `fields_get("mail.message", ["x_microsoft_message_id"])` with no keyword arguments. The existing mock-driven tests never caught this because a bare `Mock` accepts any signature. 9 passed, 4 skipped; ruff clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015SbUB7ppTjbVrnmSKmDEit)_