### PR TITLE
release: 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 
 ## [Unreleased]
 
+## [2.4.1] - 2026-07-26
+
 ### Fixed
 - `post_message` no longer raises a `TypeError` on every call. The probe that
   checks whether `mail.message` carries `x_microsoft_message_id` passed an

--- a/mcp_server_odoo/__init__.py
+++ b/mcp_server_odoo/__init__.py
@@ -6,7 +6,7 @@
 # This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """MCP Server for Odoo - Model Context Protocol server for Odoo ERP systems."""
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 __author__ = "Andrey Ivanov"
 __license__ = "MPL-2.0"
 

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -41,7 +41,7 @@ logger = get_logger(__name__)
 
 # Server version. Must match __version__ and pyproject.toml; enforced by
 # tests/test_version_consistency.py so it cannot silently drift.
-SERVER_VERSION = "2.4.0"
+SERVER_VERSION = "2.4.1"
 GIT_COMMIT = os.environ.get("GIT_COMMIT", "unknown")
 _BUILD_ORIGIN = "pnl-mcp-7f3a"  # Pantalytics provenance tag
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-server-odoo"
-version = "2.4.0"
+version = "2.4.1"
 description = "AI connector for Odoo ERP -- connect Claude, ChatGPT, and other AI tools to Odoo via MCP (Model Context Protocol)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## What

Cuts 2.4.1, which carries the `post_message` `TypeError` fix from #100.

- `pyproject.toml`, `mcp_server_odoo/__init__.py` and `mcp_server_odoo/server.py` all move to 2.4.1. These three are the set that has to stay in lockstep (see the 2.3.3 entry, where they had drifted).
- The changelog entry graduates from `Unreleased` to `[2.4.1] - 2026-07-26`.

## Why now

`odoo-mcp-pro-admin` pins this package by git tag (`@v2.4.0`), so the fix cannot reach the hosted service until there is a v2.4.1 tag to point at. The admin-side pin bump follows once this lands.

## Tests

571 passed, 98 skipped. Ruff clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015SbUB7ppTjbVrnmSKmDEit)_