### PR TITLE
fix: access checks no longer freeze the event loop when a customer Odoo hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 
 ## [Unreleased]
 
+### Fixed
+- One user with an unreachable Odoo could briefly stall the whole server.
+  Model access checks ran on the event loop and probed all four CRUD
+  operations even when the first probe timed out (up to 2 minutes of
+  freeze per check). Access checks now run in a worker thread like every
+  other Odoo call, stop at the first timeout, and report "Odoo unreachable"
+  instead of a misleading "operation not allowed".
+
 ## [2.4.1] - 2026-07-26
 
 ### Fixed

--- a/mcp_server_odoo/exceptions.py
+++ b/mcp_server_odoo/exceptions.py
@@ -11,3 +11,14 @@ class OdooConnectionError(Exception):
     """Exception raised when connection to Odoo fails."""
 
     pass
+
+
+class OdooTimeoutError(OdooConnectionError):
+    """A request to the Odoo server timed out.
+
+    Distinct from OdooConnectionError so callers that probe repeatedly
+    (e.g. the per-operation permission checks) can stop after the first
+    timeout instead of paying the full timeout once per probe.
+    """
+
+    pass

--- a/mcp_server_odoo/odoo_connection/__init__.py
+++ b/mcp_server_odoo/odoo_connection/__init__.py
@@ -10,11 +10,12 @@ This package provides the OdooConnection class for managing connections
 to Odoo via XML-RPC using MCP-specific endpoints.
 """
 
-from ..exceptions import OdooConnectionError
+from ..exceptions import OdooConnectionError, OdooTimeoutError
 from .core import OdooConnection, create_connection
 
 __all__ = [
     "OdooConnection",
     "OdooConnectionError",
+    "OdooTimeoutError",
     "create_connection",
 ]

--- a/mcp_server_odoo/odoo_connection/orm.py
+++ b/mcp_server_odoo/odoo_connection/orm.py
@@ -18,7 +18,7 @@ import xmlrpc.client
 from typing import Any, Dict, List, Optional, Union
 
 from ..error_sanitizer import ErrorSanitizer
-from ..exceptions import OdooConnectionError
+from ..exceptions import OdooConnectionError, OdooTimeoutError
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +120,7 @@ class OdooConnectionOrmMixin:
             raise OdooConnectionError(f"Operation failed: {sanitized_message}") from e
         except socket.timeout:
             logger.error(f"Timeout during {method} on {model}")
-            raise OdooConnectionError(f"Operation timeout after {self.timeout} seconds") from None
+            raise OdooTimeoutError(f"Operation timeout after {self.timeout} seconds") from None
         except Exception as e:
             logger.error(f"Error during {method} on {model}: {e}")
             # Sanitize generic errors as well
@@ -394,6 +394,12 @@ class OdooConnectionOrmMixin:
                 model, "check_access_rights", [operation], {"raise_exception": False}
             )
             return bool(result)
+        except OdooTimeoutError:
+            # The server is not answering; the other CRUD probes would each
+            # eat the same full timeout. Propagate so the caller stops probing
+            # and the user sees "Odoo unreachable" instead of a 4x-timeout
+            # stall ending in a misleading "not allowed".
+            raise
         except Exception as e:
             # If model doesn't exist (module not installed), assume no access
             error_str = str(e).lower()

--- a/mcp_server_odoo/odoo_json2_connection.py
+++ b/mcp_server_odoo/odoo_json2_connection.py
@@ -18,7 +18,7 @@ from curl_cffi.requests.errors import RequestsError
 
 from .config import OdooConfig
 from .error_sanitizer import ErrorSanitizer
-from .exceptions import OdooConnectionError  # noqa: F401
+from .exceptions import OdooConnectionError, OdooTimeoutError  # noqa: F401
 from .odoo_json2_orm import Json2OrmMixin
 
 logger = logging.getLogger(__name__)
@@ -124,7 +124,7 @@ class OdooJSON2Connection(Json2OrmMixin):
         except RequestsError as e:
             msg = str(e).lower()
             if "timeout" in msg or "timed out" in msg:
-                raise OdooConnectionError(
+                raise OdooTimeoutError(
                     f"Request timeout after {self.timeout}s: {model}/{method}"
                 ) from None
             if "resolve" in msg or "connect" in msg:

--- a/mcp_server_odoo/odoo_json2_orm.py
+++ b/mcp_server_odoo/odoo_json2_orm.py
@@ -12,7 +12,7 @@ Transport code (HTTP client, _call, error parsing) lives in
 import logging
 from typing import Any, Dict, List, Optional, Union
 
-from .exceptions import OdooConnectionError
+from .exceptions import OdooConnectionError, OdooTimeoutError
 
 logger = logging.getLogger(__name__)
 
@@ -237,6 +237,10 @@ class Json2OrmMixin:
                 raise_exception=False,
             )
             return bool(result)
+        except OdooTimeoutError:
+            # The server is not answering; the other CRUD probes would each
+            # eat the same full timeout. Propagate so the caller stops probing.
+            raise
         except OdooConnectionError as e:
             # If check_access_rights returns 404, the method may not be exposed
             # via JSON/2 on this Odoo instance. Assume access is granted and let

--- a/mcp_server_odoo/resources/retrieval.py
+++ b/mcp_server_odoo/resources/retrieval.py
@@ -19,6 +19,7 @@ from ..error_handling import (
 )
 from ..logging_config import get_logger, perf_logger
 from ..odoo_connection import OdooConnectionError
+from ..tools._common import validate_access
 
 logger = get_logger(__name__)
 
@@ -60,7 +61,7 @@ class RetrievalMixin:
 
                 # Check model access permissions
                 try:
-                    access_controller.validate_model_access(model, "read")
+                    await validate_access(connection, access_controller, model, "read")
                 except AccessControlError as e:
                     logger.warning(f"Access denied for {model}.read: {e}")
                     raise PermissionError(f"Access denied: {e}", context=context) from e
@@ -158,7 +159,7 @@ class RetrievalMixin:
             connection, access_controller = await self._get_user_context()
             # Check model access permissions
             try:
-                access_controller.validate_model_access(model, "read")
+                await validate_access(connection, access_controller, model, "read")
             except AccessControlError as e:
                 logger.warning(f"Access denied for {model}.read: {e}")
                 raise PermissionError(f"Access denied: {e}") from e
@@ -239,7 +240,7 @@ class RetrievalMixin:
             connection, access_controller = await self._get_user_context()
             # Check model access permissions
             try:
-                access_controller.validate_model_access(model, "read")
+                await validate_access(connection, access_controller, model, "read")
             except AccessControlError as e:
                 logger.warning(f"Access denied for {model}.read: {e}")
                 raise PermissionError(f"Access denied: {e}") from e
@@ -289,7 +290,7 @@ class RetrievalMixin:
             connection, access_controller = await self._get_user_context()
             # Check model access permissions
             try:
-                access_controller.validate_model_access(model, "read")
+                await validate_access(connection, access_controller, model, "read")
             except AccessControlError as e:
                 logger.warning(f"Access denied for {model}.read: {e}")
                 raise PermissionError(f"Access denied: {e}") from e

--- a/mcp_server_odoo/tools/_common.py
+++ b/mcp_server_odoo/tools/_common.py
@@ -77,3 +77,20 @@ async def run_blocking(connection: Any, func: Callable[..., T], /, *args: Any, *
     """
     async with _lock_for(connection):
         return await asyncio.to_thread(func, *args, **kwargs)
+
+
+async def validate_access(
+    connection: Any, access_controller: Any, model: str, operation: str
+) -> None:
+    """Run a model access check off the event loop.
+
+    On a cache miss the access controller probes the customer's Odoo over the
+    network (one check_access_rights call per CRUD operation), so it must run
+    via `run_blocking` like every other Odoo call. Running it inline froze the
+    whole event loop for up to 4x the RPC timeout when a customer's Odoo hung
+    (2026-08-10 incident), and bypassed the per-connection transport lock.
+
+    Raises AccessControlError if access is denied, OdooTimeoutError if the
+    customer's Odoo does not answer.
+    """
+    await run_blocking(connection, access_controller.validate_model_access, model, operation)

--- a/mcp_server_odoo/tools/binary.py
+++ b/mcp_server_odoo/tools/binary.py
@@ -22,6 +22,7 @@ from ._common import (
     _current_sub,
     logger,
     run_blocking,
+    validate_access,
 )
 
 
@@ -116,7 +117,7 @@ class BinaryToolsMixin:
                     connection_selector, writes=True
                 )
                 with perf_logger.track_operation("tool_set_binary_field", model=model):
-                    access_controller.validate_model_access(model, "write")
+                    await validate_access(connection, access_controller, model, "write")
                     if not connection.is_authenticated:
                         raise ValidationError("Not authenticated with Odoo")
                     if not field_name:

--- a/mcp_server_odoo/tools/bulk.py
+++ b/mcp_server_odoo/tools/bulk.py
@@ -17,7 +17,7 @@ from ..schemas import (
     BulkUpdateResult,
     ImportResult,
 )
-from ._common import MAX_BULK_SIZE, _current_sub, logger, run_blocking
+from ._common import MAX_BULK_SIZE, _current_sub, logger, run_blocking, validate_access
 
 
 class BulkToolsMixin:
@@ -195,7 +195,7 @@ class BulkToolsMixin:
                 connection_selector, writes=True
             )
             with perf_logger.track_operation("tool_create_records", model=model):
-                access_controller.validate_model_access(model, "create")
+                await validate_access(connection, access_controller, model, "create")
                 if not connection.is_authenticated:
                     raise ValidationError("Not authenticated with Odoo")
                 if not vals_list:
@@ -241,7 +241,7 @@ class BulkToolsMixin:
                 connection_selector, writes=True
             )
             with perf_logger.track_operation("tool_update_records", model=model):
-                access_controller.validate_model_access(model, "write")
+                await validate_access(connection, access_controller, model, "write")
                 if not connection.is_authenticated:
                     raise ValidationError("Not authenticated with Odoo")
                 if not record_ids:
@@ -286,7 +286,7 @@ class BulkToolsMixin:
                 connection_selector, writes=True
             )
             with perf_logger.track_operation("tool_delete_records", model=model):
-                access_controller.validate_model_access(model, "unlink")
+                await validate_access(connection, access_controller, model, "unlink")
                 if not connection.is_authenticated:
                     raise ValidationError("Not authenticated with Odoo")
                 if not record_ids:
@@ -331,8 +331,8 @@ class BulkToolsMixin:
                 connection_selector, writes=True
             )
             with perf_logger.track_operation("tool_import_records", model=model):
-                access_controller.validate_model_access(model, "create")
-                access_controller.validate_model_access(model, "write")
+                await validate_access(connection, access_controller, model, "create")
+                await validate_access(connection, access_controller, model, "write")
                 if not connection.is_authenticated:
                     raise ValidationError("Not authenticated with Odoo")
                 if not fields:

--- a/mcp_server_odoo/tools/crud.py
+++ b/mcp_server_odoo/tools/crud.py
@@ -18,7 +18,7 @@ from ..error_sanitizer import ErrorSanitizer
 from ..logging_config import perf_logger
 from ..odoo_connection import OdooConnectionError
 from ..schemas import CreateResult, DeleteResult, UpdateResult
-from ._common import _current_sub, logger, run_blocking
+from ._common import _current_sub, logger, run_blocking, validate_access
 
 
 class CrudToolsMixin:
@@ -132,7 +132,7 @@ class CrudToolsMixin:
             )
             with perf_logger.track_operation("tool_create_record", model=model):
                 # Check model access
-                access_controller.validate_model_access(model, "create")
+                await validate_access(connection, access_controller, model, "create")
 
                 # Ensure we're connected
                 if not connection.is_authenticated:
@@ -213,7 +213,7 @@ class CrudToolsMixin:
             )
             with perf_logger.track_operation("tool_update_record", model=model):
                 # Check model access
-                access_controller.validate_model_access(model, "write")
+                await validate_access(connection, access_controller, model, "write")
 
                 # Ensure we're connected
                 if not connection.is_authenticated:
@@ -304,7 +304,7 @@ class CrudToolsMixin:
             )
             with perf_logger.track_operation("tool_delete_record", model=model):
                 # Check model access
-                access_controller.validate_model_access(model, "unlink")
+                await validate_access(connection, access_controller, model, "unlink")
 
                 # Ensure we're connected
                 if not connection.is_authenticated:

--- a/mcp_server_odoo/tools/messaging.py
+++ b/mcp_server_odoo/tools/messaging.py
@@ -13,7 +13,7 @@ from ..error_sanitizer import ErrorSanitizer
 from ..logging_config import perf_logger
 from ..odoo_connection import OdooConnectionError
 from ..schemas import PostMessageResult
-from ._common import _current_sub, logger, run_blocking
+from ._common import _current_sub, logger, run_blocking, validate_access
 
 
 class MessagingToolsMixin:
@@ -135,7 +135,7 @@ class MessagingToolsMixin:
             )
             with perf_logger.track_operation("tool_post_message", model=model):
                 # Posting to chatter requires write access on the model
-                access_controller.validate_model_access(model, "write")
+                await validate_access(connection, access_controller, model, "write")
 
                 if not connection.is_authenticated:
                     raise ValidationError("Not authenticated with Odoo")

--- a/mcp_server_odoo/tools/methods.py
+++ b/mcp_server_odoo/tools/methods.py
@@ -23,7 +23,7 @@ from ..error_sanitizer import ErrorSanitizer
 from ..logging_config import perf_logger
 from ..odoo_connection import OdooConnectionError
 from ..schemas import ExecuteMethodResult
-from ._common import _current_sub, logger, run_blocking
+from ._common import _current_sub, logger, run_blocking, validate_access
 from .wizards import WizardHandler, followup_descriptor, get_handler
 
 _ACTION_SHAPE_KEYS = ("view_mode", "views", "target", "res_id", "domain")
@@ -165,7 +165,7 @@ class MethodsToolsMixin:
 
                 # Touching a model at all needs read access; everything beyond that
                 # is enforced by Odoo when the method runs.
-                access_controller.validate_model_access(model, "read")
+                await validate_access(connection, access_controller, model, "read")
 
                 if not connection.is_authenticated:
                     raise ValidationError("Not authenticated with Odoo")

--- a/mcp_server_odoo/tools/query.py
+++ b/mcp_server_odoo/tools/query.py
@@ -19,7 +19,7 @@ from ..error_sanitizer import ErrorSanitizer
 from ..logging_config import perf_logger
 from ..odoo_connection import OdooConnectionError
 from ..schemas import FieldSelectionMetadata, RecordResult, SearchResult
-from ._common import _current_sub, logger, run_blocking
+from ._common import _current_sub, logger, run_blocking, validate_access
 
 
 class QueryToolsMixin:
@@ -147,7 +147,7 @@ class QueryToolsMixin:
             connection, access_controller, sub = await self._get_user_context(connection_selector)
             with perf_logger.track_operation("tool_search", model=model):
                 # Check model access
-                access_controller.validate_model_access(model, "read")
+                await validate_access(connection, access_controller, model, "read")
 
                 # Ensure we're connected
                 if not connection.is_authenticated:
@@ -284,7 +284,7 @@ class QueryToolsMixin:
             connection, access_controller, sub = await self._get_user_context(connection_selector)
             with perf_logger.track_operation("tool_get_record", model=model):
                 # Check model access
-                access_controller.validate_model_access(model, "read")
+                await validate_access(connection, access_controller, model, "read")
 
                 # Ensure we're connected
                 if not connection.is_authenticated:

--- a/tests/test_access_control.py
+++ b/tests/test_access_control.py
@@ -5,6 +5,7 @@ for both JSON/2 and XML-RPC connections.
 """
 
 import os
+import threading
 from unittest.mock import MagicMock
 
 import pytest
@@ -14,6 +15,10 @@ from mcp_server_odoo.access_control import (
     AccessController,
 )
 from mcp_server_odoo.config import OdooConfig
+from mcp_server_odoo.exceptions import OdooConnectionError, OdooTimeoutError
+from mcp_server_odoo.odoo_connection.orm import OdooConnectionOrmMixin
+from mcp_server_odoo.odoo_json2_orm import Json2OrmMixin
+from mcp_server_odoo.tools._common import validate_access
 
 from .conftest import ODOO_SERVER_AVAILABLE
 
@@ -325,3 +330,96 @@ class TestAccessControlJSON2:
 if __name__ == "__main__":
     # Run integration tests when executed directly
     pytest.main([__file__, "-v", "-k", "Integration"])
+
+
+class TestAccessCheckTimeouts:
+    """Fail-fast when the customer's Odoo stops answering (2026-08-10 incident).
+
+    A hanging Odoo used to cost 4x the RPC timeout per permissions fetch (one
+    per CRUD probe) and the checks ran on the event loop, freezing the whole
+    server. These tests pin the new behavior: stop after the first timeout,
+    surface OdooTimeoutError, and run checks off the loop via validate_access.
+    """
+
+    @pytest.fixture
+    def config(self):
+        return OdooConfig(
+            url="http://localhost:8069",
+            api_key="test_key",
+            database="testdb",
+            api_version="json2",
+        )
+
+    def test_permissions_fetch_stops_after_first_timeout(self, config):
+        conn = MagicMock()
+        conn.check_access_rights.side_effect = OdooTimeoutError(
+            "Operation timeout after 30 seconds"
+        )
+        ctrl = AccessController(config, connection=conn)
+
+        with pytest.raises(OdooTimeoutError):
+            ctrl.validate_model_access("res.partner", "read")
+
+        # One probe, not one per CRUD operation
+        assert conn.check_access_rights.call_count == 1
+
+    def test_timeout_is_not_cached_as_denial(self, config):
+        conn = MagicMock()
+        conn.check_access_rights.side_effect = OdooTimeoutError("timeout")
+        ctrl = AccessController(config, connection=conn)
+
+        with pytest.raises(OdooTimeoutError):
+            ctrl.validate_model_access("res.partner", "read")
+
+        # Once the server answers again, permissions are fetched fresh
+        conn.check_access_rights.side_effect = None
+        conn.check_access_rights.return_value = True
+        perms = ctrl.get_model_permissions("res.partner")
+        assert perms.can_read is True
+
+    def test_xmlrpc_check_access_rights_propagates_timeout(self):
+        conn = MagicMock()
+        conn.execute_kw.side_effect = OdooTimeoutError("Operation timeout after 30 seconds")
+
+        with pytest.raises(OdooTimeoutError):
+            OdooConnectionOrmMixin.check_access_rights(conn, "res.partner", "read")
+
+    def test_xmlrpc_check_access_rights_other_errors_still_allow(self):
+        # Non-timeout network errors keep the old behavior: assume allowed,
+        # let the real operation fail with a clear error.
+        conn = MagicMock()
+        conn.execute_kw.side_effect = OdooConnectionError("Operation failed: boom")
+        assert OdooConnectionOrmMixin.check_access_rights(conn, "res.partner", "read") is True
+
+        conn.execute_kw.side_effect = OdooConnectionError("Model doesn't exist")
+        assert OdooConnectionOrmMixin.check_access_rights(conn, "res.partner", "read") is False
+
+    def test_json2_check_access_rights_propagates_timeout(self):
+        conn = MagicMock()
+        conn._call.side_effect = OdooTimeoutError("Request timeout after 30s")
+
+        with pytest.raises(OdooTimeoutError):
+            Json2OrmMixin.check_access_rights(conn, "res.partner", "read")
+
+    async def test_validate_access_runs_off_the_event_loop(self, config):
+        calls = []
+
+        def record_thread(model, operation):
+            calls.append(threading.current_thread())
+
+        ctrl = MagicMock()
+        ctrl.validate_model_access.side_effect = record_thread
+        conn = MagicMock()
+
+        await validate_access(conn, ctrl, "res.partner", "read")
+
+        ctrl.validate_model_access.assert_called_once_with("res.partner", "read")
+        assert calls[0] is not threading.main_thread()
+
+    async def test_validate_access_propagates_denial(self, config):
+        ctrl = MagicMock()
+        ctrl.validate_model_access.side_effect = AccessControlError("denied")
+        conn = MagicMock()
+
+        with pytest.raises(AccessControlError):
+            await validate_access(conn, ctrl, "res.partner", "write")


### PR DESCRIPTION
Fixes #107.

## Problem

On 2026-08-10 production froze 4 times for ~2 minutes each (503 on every route). One user was connected to a hanging Odoo.sh staging build. Model access checks:

1. ran synchronously on the event loop (bypassing the `run_blocking` thread + per-connection lock from #759),
2. probed all four CRUD operations even when the first probe timed out (`check_access_rights` swallowed the timeout and returned True), so one cache miss cost 4 x 30s = 120s of total freeze,
3. colliding with in-flight threaded calls on the same transport caused the `Request-sent` (CannotSendRequest) errors seen in the logs.

## Fix

- **`OdooTimeoutError`** (subclass of `OdooConnectionError`): both transports raise it on request timeout, so callers can tell "server not answering" from "operation failed".
- **`check_access_rights`** (xmlrpc + json2): propagates timeouts instead of swallowing them. The permissions fetch stops after the first probe and the tool call fails with "Odoo unreachable" instead of stalling 2 minutes and then misleading with "operation not allowed". Other network errors keep the existing assume-allowed behavior; "model doesn't exist" still means no access.
- **`validate_access` helper** in `tools/_common.py`: runs the check via `run_blocking` (worker thread + per-connection transport lock). All 17 call sites converted (13 in `tools/`, 4 in `resources/retrieval.py`).

## Out of scope (follow-up)

The resource handlers' data calls (`connection.search`/`read` in `resources/retrieval.py`) still run synchronously on the event loop; a single hanging call can block for one timeout (30s), just no longer 4x. Will file separately.

## Testing

- New `TestAccessCheckTimeouts`: fail-fast after first timeout, timeout not cached as denial, both transports propagate `OdooTimeoutError`, helper runs off the main thread and propagates denials.
- `pytest -m 'not integration'`: 577 passed, 30 skipped. `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)