### PR TITLE
fix: resource reads no longer block the event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 
 ## [Unreleased]
 
+### Fixed
+- Resource reads (record, search, count, fields) now run in a worker thread
+  like tool calls do, so a hanging customer Odoo can no longer stall other
+  users for the duration of the RPC timeout while a resource is being read.
+
 ## [2.4.2] - 2026-08-10
 
 ### Fixed

--- a/mcp_server_odoo/resources/retrieval.py
+++ b/mcp_server_odoo/resources/retrieval.py
@@ -19,7 +19,7 @@ from ..error_handling import (
 )
 from ..logging_config import get_logger, perf_logger
 from ..odoo_connection import OdooConnectionError
-from ..tools._common import validate_access
+from ..tools._common import run_blocking, validate_access
 
 logger = get_logger(__name__)
 
@@ -71,7 +71,9 @@ class RetrievalMixin:
                     raise ValidationError("Not authenticated with Odoo", context=context)
 
             # Search for the record to check if it exists
-            record_ids = connection.search(model, [("id", "=", record_id_int)])
+            record_ids = await run_blocking(
+                connection, connection.search, model, [("id", "=", record_id_int)]
+            )
 
             if not record_ids:
                 raise NotFoundError(
@@ -81,7 +83,7 @@ class RetrievalMixin:
             # Read the record with smart field selection to avoid serialization issues
             # Get field metadata to determine which fields to fetch
             try:
-                fields_info = connection.fields_get(model)
+                fields_info = await run_blocking(connection, connection.fields_get, model)
                 # Filter out fields that might cause serialization issues
                 safe_fields = []
                 for field_name, field_info in fields_info.items():
@@ -97,14 +99,16 @@ class RetrievalMixin:
                         safe_fields.append(field_name)
 
                 if safe_fields:
-                    records = connection.read(model, record_ids, safe_fields)
+                    records = await run_blocking(
+                        connection, connection.read, model, record_ids, safe_fields
+                    )
                 else:
                     # Fallback to all fields if we can't determine safe fields
-                    records = connection.read(model, record_ids)
+                    records = await run_blocking(connection, connection.read, model, record_ids)
             except Exception as e:
                 logger.debug(f"Could not get field metadata, reading all fields: {e}")
                 # If we can't get field info, try to read all fields
-                records = connection.read(model, record_ids)
+                records = await run_blocking(connection, connection.read, model, record_ids)
 
             if not records:
                 raise NotFoundError(f"Record not found: {model} with ID {record_id} does not exist")
@@ -176,21 +180,31 @@ class RetrievalMixin:
             order_value = self._parse_order(order)
 
             # Get total count for pagination
-            total_count = connection.search_count(model, parsed_domain)
+            total_count = await run_blocking(
+                connection, connection.search_count, model, parsed_domain
+            )
 
             # Perform search
-            record_ids = connection.search(
-                model, parsed_domain, limit=limit_value, offset=offset_value, order=order_value
+            record_ids = await run_blocking(
+                connection,
+                connection.search,
+                model,
+                parsed_domain,
+                limit=limit_value,
+                offset=offset_value,
+                order=order_value,
             )
 
             # Read records if any found
             records = []
             if record_ids:
-                records = connection.read(model, record_ids, fields_list)
+                records = await run_blocking(
+                    connection, connection.read, model, record_ids, fields_list
+                )
 
             # Get field metadata for formatting
             try:
-                fields_metadata = connection.fields_get(model)
+                fields_metadata = await run_blocking(connection, connection.fields_get, model)
             except Exception as e:
                 logger.debug(f"Could not retrieve field metadata: {e}")
                 fields_metadata = None
@@ -253,7 +267,7 @@ class RetrievalMixin:
             parsed_domain = self._parse_domain(domain)
 
             # Get count
-            count = connection.search_count(model, parsed_domain)
+            count = await run_blocking(connection, connection.search_count, model, parsed_domain)
 
             # Format result
             formatted_result = self._format_count_result(model, count, parsed_domain)
@@ -300,7 +314,7 @@ class RetrievalMixin:
                 raise ValidationError("Not authenticated with Odoo")
 
             # Get field definitions
-            fields = connection.fields_get(model)
+            fields = await run_blocking(connection, connection.fields_get, model)
 
             # Format result
             formatted_result = self._format_fields_result(model, fields)

--- a/tests/test_basic_resources.py
+++ b/tests/test_basic_resources.py
@@ -318,3 +318,37 @@ class TestResourceIntegration:
 
         finally:
             connection.disconnect()
+
+
+class TestResourceCallsRunOffLoop:
+    """Resource data calls must not run on the event loop (issue #109).
+
+    A hanging customer Odoo used to block every tenant for the duration of
+    the RPC timeout because the resource handlers called the connection
+    synchronously. This pins that they now run in a worker thread.
+    """
+
+    @pytest.mark.asyncio
+    async def test_record_retrieval_runs_connection_calls_off_loop(
+        self, resource_handler, mock_connection
+    ):
+        import threading
+
+        calling_threads = []
+
+        def search(*args, **kwargs):
+            calling_threads.append(threading.current_thread())
+            return [1]
+
+        def read(*args, **kwargs):
+            calling_threads.append(threading.current_thread())
+            return [{"id": 1, "name": "Test Partner"}]
+
+        mock_connection.search = search
+        mock_connection.read = read
+        mock_connection.fields_get = lambda *a, **k: {}
+
+        await resource_handler._handle_record_retrieval("res.partner", "1")
+
+        assert calling_threads, "connection was never called"
+        assert all(t is not threading.main_thread() for t in calling_threads)


### PR DESCRIPTION
Fixes #109. Follow-up to #108.

The resource handlers (record retrieval, search, count, fields) are async but called `connection.search` / `read` / `search_count` / `fields_get` synchronously on the event loop. One hanging customer Odoo blocked every tenant for up to one RPC timeout per call, and the unthreaded calls bypassed the per-connection transport lock (the same `Request-sent` collision class seen in the 2026-08-10 incident).

All 11 data calls in `resources/retrieval.py` now go through `run_blocking` (worker thread + per-connection lock), same as the tool handlers (#759) and the access checks (#108).

## Testing

- New test pins that record retrieval runs its connection calls off the main thread.
- `pytest -m 'not integration'`: 579 passed. `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)