### PR TITLE
feat: get_image tool, plus the plan for visuals (ADR 0003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 
 ## [Unreleased]
 
+### Added
+- `get_image` tool: reads an Odoo image field (product photo, contact avatar,
+  company logo) and returns it as a real picture instead of the base64 blob
+  that every other read path filters out. Picks the Odoo image variant matching
+  the requested `size` (128/256/512/1024/1920, default 512), sniffs the format
+  from the bytes, and refuses anything a client cannot display. Read-only, ACL
+  checked like every other tool, capped at 5 MB per image.
+- ADR 0003 sets out the wider plan for visuals, including the MCP Apps
+  extension (`io.modelcontextprotocol/ui`) as the next phase.
+
 ## [2.4.3] - 2026-08-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ collection time).
 | File | Role |
 |------|------|
 | `server.py` | Factory pattern, FastMCP setup, stdio/HTTP runners |
-| `tools/` | MCP tools as mixins on `OdooToolHandler` (crud, query, bulk, binary, messaging, introspection) |
+| `tools/` | MCP tools as mixins on `OdooToolHandler` (crud, query, bulk, binary, images, messaging, introspection) |
 | `resources/` | MCP resources (URI-based): handler, retrieval, formatting |
 | `schemas.py` | Pydantic result models |
 | `odoo_json2_connection.py` | JSON/2 client (httpx, Odoo 19+); ORM mixin in `odoo_json2_orm.py` |

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ odoo-mcp-pro is an Odoo connector that implements [MCP (Model Context Protocol)]
 | `update_record` / `update_records` | Update one or multiple records |
 | `delete_record` / `delete_records` | Delete one or multiple records |
 | `import_records` | Idempotent upsert via external IDs (same as Odoo CSV import) |
+| `get_image` | Show a record's picture: product photo, contact avatar, logo |
 | `server_info` | Server version, connection status |
 
 **Supports Odoo 14-19+** -- uses the JSON/2 API for Odoo 19+ and XML-RPC for older versions. The right protocol is selected automatically.

--- a/docs/adr/0003-visuals-images-and-mcp-apps.md
+++ b/docs/adr/0003-visuals-images-and-mcp-apps.md
@@ -1,0 +1,128 @@
+# ADR 0003: Visuals - images now, MCP Apps next
+
+- Status: Accepted (phase 1), Proposed (phases 2-4)
+- Date: 2026-08-20
+- Deciders: Rutger
+- Scope: `tools/images.py` (new), later `apps/` (new), `tools/query.py`,
+  packaging in `pyproject.toml`, and the admin package's usage tracking.
+
+## Context
+
+Everything this server returns today is text or JSON. Odoo is full of things
+that are easier to look at than to read: product photos, partner avatars,
+company logos, pipelines, revenue per month, an invoice PDF. The MCP
+specification has grown two separate ways to send those, and they are worth
+keeping apart because they cost us very different amounts of work.
+
+**Core content types.** `ImageContent` (base64 plus a mime type), `AudioContent`,
+resource links and embedded resources have been part of the protocol since the
+first revision. Any client that speaks MCP renders them. We simply never used
+them: binary and image fields are filtered out of every read path
+(`tools/formatting.py`, `formatters.py`, `resources/retrieval.py`) and
+`tools/binary.py` is upload-only.
+
+**MCP Apps** (extension identifier `io.modelcontextprotocol/ui`, SEP-1865,
+extension spec revision 2026-01-26). A tool carries `_meta.ui.resourceUri`
+pointing at a `ui://` resource whose mime type is `text/html;profile=mcp-app`.
+The host renders that HTML in a sandboxed iframe, pushes the tool result to it
+(`ui/notifications/tool-result`, where `structuredContent` is meant for the UI
+and `content` for the model), and the iframe may call back with `tools/call`,
+`resources/read`, `ui/open-link`, `ui/message`, `ui/request-display-mode` and
+`ui/update-model-context`. Hosts that render apps today: Claude web and
+desktop, ChatGPT, VS Code Copilot, Microsoft 365 Copilot, Cursor, Goose,
+Postman, MCPJam.
+
+Two findings shaped this ADR:
+
+1. **No SDK upgrade is required.** `FastMCP.tool(..., meta=...)` and
+   `FastMCP.resource(..., mime_type=..., meta=...)` exist in mcp 1.27.2, which
+   is our current floor pin. The official `ext-apps` repository ships a Python
+   example (`qr-server`) built on `mcp.server.fastmcp.FastMCP` that does exactly
+   this. The mcp 2.0 / 2026-07-28 migration (stateless core, `server/discover`,
+   MRTR) is a separate track and does not block visuals.
+2. **Structured output has to be switched off for image tools.** FastMCP derives
+   an output schema from the return annotation, and would then send the same
+   base64 twice: once as content, once as `structuredContent`. Passing
+   `structured_output=False` returns unstructured content only.
+
+## Decision
+
+Ship visuals in four phases, smallest first, each independently useful.
+
+### Phase 1 - images out of Odoo (this ADR's accepted part)
+
+A read-only `get_image` tool that reads an image field and returns
+`ImageContent`, mirroring `set_binary_field` on the write side.
+
+- Sizes come from Odoo's own variants (`image_128` ... `image_1920`), so we
+  never resize server-side and need no imaging dependency. Default `size=512`,
+  which is the useful/cheap trade-off: an image costs model tokens on every
+  turn it stays in context.
+- Hard cap of 5 MB per image, with an error that names the fix (ask for a
+  smaller `size`). This matches what hosts accept per image.
+- The mime type is sniffed from the bytes, not guessed from the field name.
+  Only PNG, JPEG, GIF and WebP are returned; anything else is refused with a
+  message that says what was found, because a client cannot render it anyway.
+- Non-image binaries (PDF, spreadsheets) are explicitly out of scope for this
+  phase. They need a resource link rather than inline bytes.
+
+### Phase 2 - one MCP App pilot
+
+A single `ui://` view plus the `_meta.ui.resourceUri` wiring, behind an env
+flag so self-hosters and clients without the extension are unaffected. The
+first view is a record/list viewer over the result of `search_records`, not a
+dashboard: our tools already return Pydantic models, so the server-side change
+is a `meta=` argument plus one HTML resource. Every app tool must keep
+returning meaningful text as well, since graceful degradation is required by
+the extension spec.
+
+Rules for that phase, decided now:
+
+- No npm build step and no new Python dependency. The view is a single HTML
+  file with inline JS talking the postMessage JSON-RPC dialect directly, or a
+  vendored bundle; it ships in the wheel through
+  `[tool.hatch.build.targets.wheel.force-include]`, the same mechanism the
+  `skills` directory already uses.
+- Views live in the public package. The admin package pins a tag, so anything
+  we want hosted has to be released here first.
+- App-initiated `tools/call` traffic re-enters our normal tool path, so
+  `_get_user_context` and `_track_usage` keep working unchanged. Note for
+  billing: clicks inside a view are real tool calls and count against the daily
+  limit. That is correct but it needs to be said out loud in the admin repo
+  before the pilot goes live.
+
+### Phase 3 - aggregation and charts
+
+Charts need aggregated data. We have no `read_group` tool (only
+`execute_method`), so a small read-only aggregation tool comes first, and the
+chart view renders its `structuredContent`.
+
+### Phase 4 - write preview and documents
+
+A confirm-before-write view (show the diff, then confirm) fits "Odoo is the
+boss" and reduces blind writes. Document rendering (invoice or quotation PDF)
+is deliberately last: Odoo's report endpoints expect session authentication,
+which is its own investigation.
+
+## Consequences
+
+- Images cost tokens. Defaults stay small and the tool docstring says so.
+- One more tool in the list for every user, including self-hosters. Acceptable:
+  it is read-only, annotated as such, and mirrors an existing write tool.
+- Phase 2 introduces the first HTML asset in a Python package. The packaging
+  precedent exists (`skills`), and CI must fail if the asset is missing from
+  the wheel.
+- Nothing here depends on the stateless 2026-07-28 core, so the two tracks can
+  proceed in either order.
+
+## Sources
+
+- MCP specification 2026-07-28 changelog and extensions overview
+  (`io.modelcontextprotocol/ui` negotiation).
+- MCP Apps extension specification, revision 2026-01-26 (`ui://` resources,
+  `text/html;profile=mcp-app`, `_meta.ui.*`, the `ui/` method dialect).
+- Extension client support matrix.
+- `modelcontextprotocol/ext-apps`, `examples/qr-server` (Python server on
+  `mcp.server.fastmcp`).
+- `modelcontextprotocol/python-sdk` v1.27.2 source: `FastMCP.tool`,
+  `FastMCP.resource`, `func_metadata.convert_result`.

--- a/mcp_server_odoo/tools/__init__.py
+++ b/mcp_server_odoo/tools/__init__.py
@@ -21,6 +21,7 @@ from ._common import (
     MAX_BINARY_SIZE_BYTES,
     MAX_BULK_SIZE,
     MAX_CONCURRENT_BINARY_UPLOADS,
+    MAX_IMAGE_BYTES,
     _current_sub,
     logger,
 )
@@ -30,6 +31,7 @@ __all__ = [
     "MAX_BINARY_SIZE_BYTES",
     "MAX_BULK_SIZE",
     "MAX_CONCURRENT_BINARY_UPLOADS",
+    "MAX_IMAGE_BYTES",
     "OdooToolHandler",
     "ValidationError",
     "register_tools",

--- a/mcp_server_odoo/tools/_common.py
+++ b/mcp_server_odoo/tools/_common.py
@@ -20,6 +20,7 @@ logger = get_logger("mcp_server_odoo.tools")
 
 MAX_BULK_SIZE = 1000  # Maximum records per bulk operation
 MAX_BINARY_SIZE_BYTES = 25 * 1024 * 1024  # set_binary_field upload cap
+MAX_IMAGE_BYTES = 5 * 1024 * 1024  # get_image download cap; hosts reject bigger pictures
 MAX_CONCURRENT_BINARY_UPLOADS = 3  # parallel set_binary_field calls; higher OOMs the server
 _BINARY_UPLOAD_SEMAPHORE = asyncio.Semaphore(MAX_CONCURRENT_BINARY_UPLOADS)
 _AVATAR_FIELD_RE = re.compile(r"^avatar_(128|256|512|1024|1920)$")

--- a/mcp_server_odoo/tools/handler.py
+++ b/mcp_server_odoo/tools/handler.py
@@ -26,6 +26,7 @@ from .binary import BinaryToolsMixin
 from .bulk import BulkToolsMixin
 from .crud import CrudToolsMixin
 from .formatting import FormattingMixin
+from .images import ImageToolsMixin
 from .introspection import IntrospectionToolsMixin
 from .messaging import MessagingToolsMixin
 from .methods import MethodsToolsMixin
@@ -39,6 +40,7 @@ class OdooToolHandler(
     CrudToolsMixin,
     BulkToolsMixin,
     BinaryToolsMixin,
+    ImageToolsMixin,
     MessagingToolsMixin,
     MethodsToolsMixin,
 ):
@@ -115,6 +117,7 @@ class OdooToolHandler(
         self._register_crud_tools()
         self._register_bulk_tools()
         self._register_binary_tools()
+        self._register_image_tools()
         self._register_messaging_tools()
         self._register_methods_tools()
 

--- a/mcp_server_odoo/tools/images.py
+++ b/mcp_server_odoo/tools/images.py
@@ -265,11 +265,15 @@ def _resolve_image_field(
         if is_binary(candidate):
             return candidate
 
-    available = sorted(name for name in fields_info if fields_info[name].get("type") == "image")
+    # Odoo does not report a consistent type here: odoo.com hands back "binary"
+    # for the very same image_128 that a self-hosted 17 calls "image". So the
+    # hint lists both, or the caller of a custom model is told "no image fields"
+    # while x_photo sits right there.
+    available = sorted(name for name in fields_info if is_binary(name))
     if available:
         raise ValidationError(
             f"Model '{model}' has no standard image_* variant. Pass field_name explicitly; "
-            f"image fields on this model: {', '.join(available[:10])}"
+            f"binary/image fields on this model: {', '.join(available[:10])}"
         )
     raise ValidationError(f"Model '{model}' has no image fields")
 

--- a/mcp_server_odoo/tools/images.py
+++ b/mcp_server_odoo/tools/images.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+#
+# Part of odoo-mcp-pro. This file stays under the Mozilla Public License 2.0;
+# see LICENSE.MPL-2.0.
+"""Image read MCP tool.
+
+Returns Odoo image fields as real pictures (MCP ``ImageContent``) instead of
+the base64 blob that every other read path deliberately filters out. See
+docs/adr/0003-visuals-images-and-mcp-apps.md for the wider plan.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from typing import Any, Dict, List, Optional
+
+from mcp.types import ContentBlock, ImageContent, TextContent, ToolAnnotations
+
+from ..access_control import AccessControlError
+from ..error_handling import NotFoundError, ValidationError
+from ..error_sanitizer import ErrorSanitizer
+from ..logging_config import perf_logger
+from ..odoo_connection import OdooConnectionError
+from ._common import (
+    MAX_IMAGE_BYTES,
+    _current_sub,
+    logger,
+    run_blocking,
+    validate_access,
+)
+
+# Odoo's own stored image variants, smallest to largest. Odoo computes these
+# from image_1920, so asking for a small one is free: no server-side resizing,
+# no imaging dependency.
+IMAGE_SIZES = (128, 256, 512, 1024, 1920)
+DEFAULT_IMAGE_SIZE = 512
+
+# Preference order when the caller does not name a field: the requested size
+# first, then the remaining variants smallest-first (cheap before expensive),
+# then the bare `image` field some custom models use.
+_FALLBACK_FIELDS = tuple(f"image_{size}" for size in IMAGE_SIZES) + ("image",)
+
+# Mime types a host can actually render. Sniffed from the bytes, never guessed
+# from the field name: Odoo stores whatever was uploaded.
+_SUPPORTED_SIGNATURES = (
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+)
+# Recognized but not renderable by MCP hosts. Named separately so the error can
+# say what was found instead of "unknown format".
+_UNSUPPORTED_SIGNATURES = (
+    (b"BM", "BMP"),
+    (b"II*\x00", "TIFF"),
+    (b"MM\x00*", "TIFF"),
+    (b"%PDF-", "PDF"),
+    (b"<?xml", "SVG or XML"),
+    (b"<svg", "SVG"),
+)
+
+
+def sniff_image_mime(raw: bytes) -> str:
+    """Return the mime type of `raw`, or raise ValidationError if unusable.
+
+    Only the formats MCP hosts render are accepted. Anything else fails with a
+    message naming the format that was found, so the user knows what to convert.
+    """
+    for signature, mime_type in _SUPPORTED_SIGNATURES:
+        if raw.startswith(signature):
+            return mime_type
+    if raw[:4] == b"RIFF" and raw[8:12] == b"WEBP":
+        return "image/webp"
+
+    for signature, label in _UNSUPPORTED_SIGNATURES:
+        if raw.startswith(signature):
+            raise ValidationError(
+                f"Field contains {label} data, which MCP clients cannot display. "
+                "Only PNG, JPEG, GIF and WebP can be shown."
+            )
+    raise ValidationError(
+        "Field does not contain a recognizable image (expected PNG, JPEG, GIF or WebP)"
+    )
+
+
+def _human_size(num_bytes: int) -> str:
+    """Byte count for the summary line, readable at both ends of the range."""
+    if num_bytes < 1024:
+        return f"{num_bytes} B"
+    if num_bytes < 1024 * 1024:
+        return f"{num_bytes // 1024} KB"
+    return f"{num_bytes / (1024 * 1024):.1f} MB"
+
+
+class ImageToolsMixin:
+    """get_image tool."""
+
+    def _register_image_tools(self):
+        """Register image read tool handlers with FastMCP."""
+
+        @self.app.tool(
+            title="Get Image (Show a Record's Picture)",
+            # Without this, FastMCP derives an output schema from the return
+            # annotation and ships the same base64 twice: once as content, once
+            # as structuredContent.
+            structured_output=False,
+            annotations=ToolAnnotations(
+                readOnlyHint=True,
+                destructiveHint=False,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+        async def get_image(
+            model: str,
+            record_id: int,
+            field_name: Optional[str] = None,
+            size: int = DEFAULT_IMAGE_SIZE,
+            connection: Optional[str] = None,
+        ) -> List[ContentBlock]:
+            """Show the image stored on a record: product photo, avatar, logo.
+
+            Use this when the user wants to SEE something ("show me that
+            product", "what does this contact's avatar look like"). For reading
+            data, keep using get_record and search_records - they leave image
+            fields out on purpose.
+
+            Images cost tokens on every turn they stay in the conversation, so
+            ask for the smallest size that answers the question. 512 is the
+            default and is enough to recognize a product; 1920 is print quality
+            and rarely needed.
+
+            Only PNG, JPEG, GIF and WebP can be displayed. Non-image binaries
+            (PDF invoices, spreadsheets) are not supported by this tool.
+
+            Args:
+                model: Odoo model name (e.g. 'product.template', 'res.partner')
+                record_id: ID of the record to read
+                field_name: Optional. Specific image field, e.g. 'image_1920' or
+                    'image_variant_1920'. Leave empty to let the server pick the
+                    variant matching `size`.
+                size: Pixel variant to prefer: 128, 256, 512, 1024 or 1920.
+                    Ignored when field_name is given.
+                connection: Optional. Target a specific Odoo connection by the id
+                    from server_info's `connections` list. Hosted multi-tenant
+                    only; ignored when self-hosting a single connection.
+
+            Returns:
+                The picture, plus one line naming the field it came from.
+            """
+            info = await self._handle_get_image_tool(model, record_id, field_name, size, connection)
+            self._track_usage(_current_sub.get(), "get_image")
+            summary = (
+                f"{info['model']}({info['record_id']}).{info['field']}: "
+                f"{info['mime_type']}, {_human_size(info['size_bytes'])}. {info['url']}"
+            )
+            return [
+                TextContent(type="text", text=summary),
+                ImageContent(type="image", data=info["data"], mimeType=info["mime_type"]),
+            ]
+
+    async def _handle_get_image_tool(
+        self,
+        model: str,
+        record_id: int,
+        field_name: Optional[str] = None,
+        size: int = DEFAULT_IMAGE_SIZE,
+        connection_selector: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Handle get_image tool request.
+
+        Resolves which image field to read, reads it through the normal ACL
+        path, and returns the decoded bytes re-encoded as clean base64 together
+        with the sniffed mime type.
+        """
+        try:
+            connection, access_controller, _sub = await self._get_user_context(connection_selector)
+            with perf_logger.track_operation("tool_get_image", model=model):
+                await validate_access(connection, access_controller, model, "read")
+                if not connection.is_authenticated:
+                    raise ValidationError("Not authenticated with Odoo")
+                if size not in IMAGE_SIZES:
+                    raise ValidationError(
+                        f"size must be one of {', '.join(str(s) for s in IMAGE_SIZES)}, got {size}"
+                    )
+
+                fields_info = await run_blocking(connection, connection.fields_get, model)
+                if not isinstance(fields_info, dict):
+                    raise ValidationError(f"Could not introspect fields of {model}")
+
+                target_field = _resolve_image_field(model, fields_info, field_name, size)
+
+                records = await run_blocking(
+                    connection, connection.read, model, [record_id], [target_field]
+                )
+                if not records:
+                    raise NotFoundError(f"Record not found: {model} with ID {record_id}")
+
+                raw = _decode_image_value(
+                    records[0].get(target_field), model, record_id, target_field
+                )
+                if len(raw) > MAX_IMAGE_BYTES:
+                    raise ValidationError(
+                        f"Image is {len(raw) // (1024 * 1024)} MB, over the "
+                        f"{MAX_IMAGE_BYTES // (1024 * 1024)} MB limit. Ask for a smaller "
+                        f"size (e.g. size=256)."
+                    )
+                mime_type = sniff_image_mime(raw)
+
+                base_url = (
+                    getattr(connection, "_base_url", None)
+                    or (self.config.url if self.config else "")
+                ).rstrip("/")
+                return {
+                    "model": model,
+                    "record_id": record_id,
+                    "field": target_field,
+                    "mime_type": mime_type,
+                    "size_bytes": len(raw),
+                    "data": base64.b64encode(raw).decode("ascii"),
+                    "url": f"{base_url}/web#id={record_id}&model={model}&view_type=form",
+                }
+
+        except ValidationError:
+            raise
+        except NotFoundError as e:
+            raise ValidationError(str(e)) from e
+        except AccessControlError as e:
+            raise ValidationError(f"Access denied: {e}") from e
+        except OdooConnectionError as e:
+            raise ValidationError(f"Connection error: {e}") from e
+        except Exception as e:
+            logger.error(f"Error in get_image tool: {e}")
+            sanitized_msg = ErrorSanitizer.sanitize_message(str(e))
+            raise ValidationError(f"Failed to read image: {sanitized_msg}") from e
+
+
+def _resolve_image_field(
+    model: str,
+    fields_info: Dict[str, Any],
+    field_name: Optional[str],
+    size: int,
+) -> str:
+    """Return the field to read, or raise ValidationError explaining why not.
+
+    An explicit field_name is used as given. Without one, the variant matching
+    `size` wins, then the remaining variants, then a bare `image` field.
+    """
+
+    def is_binary(name: str) -> bool:
+        return fields_info.get(name, {}).get("type") in ("binary", "image")
+
+    if field_name:
+        if field_name not in fields_info:
+            raise ValidationError(f"Field '{field_name}' does not exist on model '{model}'")
+        if not is_binary(field_name):
+            ftype = fields_info[field_name].get("type")
+            raise ValidationError(f"Field '{field_name}' is type '{ftype}', not binary/image")
+        return field_name
+
+    candidates = [f"image_{size}"] + [f for f in _FALLBACK_FIELDS if f != f"image_{size}"]
+    for candidate in candidates:
+        if is_binary(candidate):
+            return candidate
+
+    available = sorted(name for name in fields_info if fields_info[name].get("type") == "image")
+    if available:
+        raise ValidationError(
+            f"Model '{model}' has no standard image_* variant. Pass field_name explicitly; "
+            f"image fields on this model: {', '.join(available[:10])}"
+        )
+    raise ValidationError(f"Model '{model}' has no image fields")
+
+
+def _decode_image_value(value: Any, model: str, record_id: int, field: str) -> bytes:
+    """Decode Odoo's base64 field value into bytes.
+
+    Odoo returns False for an empty binary field, a base64 str over both
+    XML-RPC and JSON/2, and occasionally bytes.
+    """
+    if not value:
+        raise ValidationError(f"{model}({record_id}).{field} is empty: no image stored")
+    if isinstance(value, bytes):
+        payload: Any = value
+    elif isinstance(value, str):
+        payload = value.encode("ascii", errors="ignore")
+    else:
+        raise ValidationError(
+            f"{model}({record_id}).{field} returned {type(value).__name__}, expected base64 data"
+        )
+    try:
+        return base64.b64decode(payload, validate=False)
+    except (binascii.Error, ValueError) as e:
+        raise ValidationError(f"{model}({record_id}).{field} is not valid base64: {e}") from e

--- a/tests/test_image_tool.py
+++ b/tests/test_image_tool.py
@@ -1,0 +1,277 @@
+"""Tests for the get_image tool."""
+
+import base64
+from unittest.mock import Mock
+
+import pytest
+
+from mcp_server_odoo.access_control import AccessControlError
+from mcp_server_odoo.error_handling import ValidationError
+from mcp_server_odoo.tools import MAX_IMAGE_BYTES, OdooToolHandler
+from mcp_server_odoo.tools.images import sniff_image_mime
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+JPEG_BYTES = b"\xff\xd8\xff\xe0" + b"\x00" * 32
+WEBP_BYTES = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP" + b"\x00" * 16
+
+IMAGE_FIELDS = {
+    "name": {"type": "char"},
+    "image_128": {"type": "image"},
+    "image_256": {"type": "image"},
+    "image_512": {"type": "image"},
+    "image_1920": {"type": "image"},
+    "notes": {"type": "text"},
+}
+
+
+def b64(raw: bytes) -> str:
+    return base64.b64encode(raw).decode("ascii")
+
+
+class TestSniffImageMime:
+    """Format detection works off the bytes, not the field name."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (PNG_BYTES, "image/png"),
+            (JPEG_BYTES, "image/jpeg"),
+            (b"GIF89a" + b"\x00" * 16, "image/gif"),
+            (WEBP_BYTES, "image/webp"),
+        ],
+    )
+    def test_supported_formats(self, raw, expected):
+        assert sniff_image_mime(raw) == expected
+
+    def test_known_but_unrenderable_format_names_itself(self):
+        with pytest.raises(ValidationError, match="PDF"):
+            sniff_image_mime(b"%PDF-1.7\n%rest")
+
+    def test_unknown_bytes_are_refused(self):
+        with pytest.raises(ValidationError, match="recognizable image"):
+            sniff_image_mime(b"just some text, not an image at all")
+
+
+class TestGetImage:
+    """Test the get_image tool handler."""
+
+    @pytest.fixture
+    def mock_app(self):
+        app = Mock()
+        app.tool = Mock(side_effect=lambda **kwargs: lambda func: func)
+        return app
+
+    @pytest.fixture
+    def mock_connection(self):
+        conn = Mock()
+        conn.is_authenticated = True
+        conn._base_url = "http://localhost:8069"
+        conn.fields_get.return_value = IMAGE_FIELDS
+        conn.read.return_value = [{"id": 7, "image_512": b64(PNG_BYTES)}]
+        return conn
+
+    @pytest.fixture
+    def mock_access_controller(self):
+        controller = Mock()
+        controller.validate_model_access = Mock()
+        return controller
+
+    @pytest.fixture
+    def mock_config(self):
+        config = Mock()
+        config.url = "http://localhost:8069"
+        return config
+
+    @pytest.fixture
+    def handler(self, mock_app, mock_connection, mock_access_controller, mock_config):
+        return OdooToolHandler(mock_app, mock_connection, mock_access_controller, mock_config)
+
+    @pytest.mark.asyncio
+    async def test_default_size_picks_matching_variant(self, handler, mock_connection):
+        """No field_name: the variant matching `size` is read."""
+        result = await handler._handle_get_image_tool("product.template", 7)
+
+        assert result["field"] == "image_512"
+        assert result["mime_type"] == "image/png"
+        assert result["size_bytes"] == len(PNG_BYTES)
+        assert base64.b64decode(result["data"]) == PNG_BYTES
+        assert result["url"] == (
+            "http://localhost:8069/web#id=7&model=product.template&view_type=form"
+        )
+        mock_connection.read.assert_called_once_with("product.template", [7], ["image_512"])
+
+    @pytest.mark.asyncio
+    async def test_requested_size_maps_to_variant_field(self, handler, mock_connection):
+        mock_connection.read.return_value = [{"id": 7, "image_128": b64(JPEG_BYTES)}]
+
+        result = await handler._handle_get_image_tool("product.template", 7, size=128)
+
+        assert result["field"] == "image_128"
+        assert result["mime_type"] == "image/jpeg"
+
+    @pytest.mark.asyncio
+    async def test_missing_variant_falls_back_to_another_one(self, handler, mock_connection):
+        """A model without image_1024 still answers, from the next variant."""
+        mock_connection.fields_get.return_value = {"image_1920": {"type": "image"}}
+        mock_connection.read.return_value = [{"id": 7, "image_1920": b64(PNG_BYTES)}]
+
+        result = await handler._handle_get_image_tool("res.partner", 7, size=1024)
+
+        assert result["field"] == "image_1920"
+
+    @pytest.mark.asyncio
+    async def test_explicit_field_is_used_verbatim(self, handler, mock_connection):
+        mock_connection.fields_get.return_value = {
+            **IMAGE_FIELDS,
+            "image_variant_1920": {"type": "image"},
+        }
+        mock_connection.read.return_value = [{"id": 7, "image_variant_1920": b64(PNG_BYTES)}]
+
+        result = await handler._handle_get_image_tool(
+            "product.product", 7, field_name="image_variant_1920", size=128
+        )
+
+        assert result["field"] == "image_variant_1920"
+        mock_connection.read.assert_called_once_with("product.product", [7], ["image_variant_1920"])
+
+    @pytest.mark.asyncio
+    async def test_non_binary_field_is_refused(self, handler):
+        with pytest.raises(ValidationError, match="not binary/image"):
+            await handler._handle_get_image_tool("product.template", 7, field_name="name")
+
+    @pytest.mark.asyncio
+    async def test_unknown_field_is_refused(self, handler):
+        with pytest.raises(ValidationError, match="does not exist"):
+            await handler._handle_get_image_tool("product.template", 7, field_name="nope")
+
+    @pytest.mark.asyncio
+    async def test_model_without_image_fields(self, handler, mock_connection):
+        mock_connection.fields_get.return_value = {"name": {"type": "char"}}
+
+        with pytest.raises(ValidationError, match="no image fields"):
+            await handler._handle_get_image_tool("account.move", 7)
+
+    @pytest.mark.asyncio
+    async def test_model_with_only_custom_image_field_lists_it(self, handler, mock_connection):
+        mock_connection.fields_get.return_value = {"x_photo": {"type": "image"}}
+
+        with pytest.raises(ValidationError, match="x_photo"):
+            await handler._handle_get_image_tool("x.model", 7)
+
+    @pytest.mark.asyncio
+    async def test_invalid_size_is_refused(self, handler):
+        with pytest.raises(ValidationError, match="size must be one of"):
+            await handler._handle_get_image_tool("product.template", 7, size=300)
+
+    @pytest.mark.asyncio
+    async def test_empty_field_says_so(self, handler, mock_connection):
+        mock_connection.read.return_value = [{"id": 7, "image_512": False}]
+
+        with pytest.raises(ValidationError, match="no image stored"):
+            await handler._handle_get_image_tool("product.template", 7)
+
+    @pytest.mark.asyncio
+    async def test_missing_record(self, handler, mock_connection):
+        mock_connection.read.return_value = []
+
+        with pytest.raises(ValidationError, match="Record not found"):
+            await handler._handle_get_image_tool("product.template", 999)
+
+    @pytest.mark.asyncio
+    async def test_oversized_image_suggests_smaller_size(self, handler, mock_connection):
+        oversized = PNG_BYTES + b"\x00" * (MAX_IMAGE_BYTES + 1)
+        mock_connection.read.return_value = [{"id": 7, "image_512": b64(oversized)}]
+
+        with pytest.raises(ValidationError, match="size=256"):
+            await handler._handle_get_image_tool("product.template", 7)
+
+    @pytest.mark.asyncio
+    async def test_pdf_in_binary_field_is_refused(self, handler, mock_connection):
+        mock_connection.fields_get.return_value = {"datas": {"type": "binary"}}
+        mock_connection.read.return_value = [{"id": 7, "datas": b64(b"%PDF-1.7 fake")}]
+
+        with pytest.raises(ValidationError, match="PDF"):
+            await handler._handle_get_image_tool("ir.attachment", 7, field_name="datas")
+
+    @pytest.mark.asyncio
+    async def test_bytes_value_is_accepted(self, handler, mock_connection):
+        """Some transports hand back bytes instead of str."""
+        mock_connection.read.return_value = [{"id": 7, "image_512": b64(PNG_BYTES).encode()}]
+
+        result = await handler._handle_get_image_tool("product.template", 7)
+
+        assert result["mime_type"] == "image/png"
+
+    @pytest.mark.asyncio
+    async def test_not_authenticated(self, handler, mock_connection):
+        mock_connection.is_authenticated = False
+
+        with pytest.raises(ValidationError, match="Not authenticated"):
+            await handler._handle_get_image_tool("product.template", 7)
+
+    @pytest.mark.asyncio
+    async def test_access_denied_is_reported(self, handler, mock_access_controller):
+        mock_access_controller.validate_model_access.side_effect = AccessControlError("nope")
+
+        with pytest.raises(ValidationError, match="Access denied"):
+            await handler._handle_get_image_tool("product.template", 7)
+
+    @pytest.mark.asyncio
+    async def test_read_only_annotation(self, handler, mock_app):
+        """The tool must be registered read-only: it never writes to Odoo."""
+        calls = [c.kwargs for c in mock_app.tool.call_args_list if "Get Image" in str(c.kwargs)]
+        assert calls, "get_image was not registered"
+        assert calls[0]["annotations"].readOnlyHint is True
+        # Structured output off, or the base64 ships twice (content + structured).
+        assert calls[0]["structured_output"] is False
+
+
+class TestGetImageOverFastMCP:
+    """The tool must behave through real FastMCP, not just the handler.
+
+    FastMCP derives an output schema from the return annotation unless
+    structured_output is off. With a schema, the same base64 would be sent
+    twice (content + structuredContent), doubling what the client downloads.
+    """
+
+    @pytest.fixture
+    def app(self):
+        from mcp.server.fastmcp import FastMCP
+
+        from mcp_server_odoo.tools import register_tools
+
+        conn = Mock()
+        conn.is_authenticated = True
+        conn._base_url = "http://localhost:8069"
+        conn.fields_get.return_value = {"image_512": {"type": "image"}}
+        conn.read.return_value = [{"id": 7, "image_512": b64(PNG_BYTES)}]
+        access = Mock()
+        access.validate_model_access = Mock()
+        config = Mock()
+        config.url = "http://localhost:8069"
+
+        app = FastMCP("test")
+        register_tools(app, conn, access, config)
+        return app
+
+    @pytest.mark.asyncio
+    async def test_tool_is_listed_without_output_schema(self, app):
+        tools = {tool.name: tool for tool in await app.list_tools()}
+
+        assert "get_image" in tools
+        assert tools["get_image"].outputSchema is None
+        assert tools["get_image"].annotations.readOnlyHint is True
+
+    @pytest.mark.asyncio
+    async def test_call_returns_text_plus_image(self, app):
+        from mcp.types import ImageContent, TextContent
+
+        result = await app.call_tool("get_image", {"model": "product.template", "record_id": 7})
+        content, structured = result if isinstance(result, tuple) else (result, None)
+
+        assert structured is None
+        assert isinstance(content[0], TextContent)
+        assert "image_512" in content[0].text
+        assert isinstance(content[1], ImageContent)
+        assert content[1].mimeType == "image/png"
+        assert base64.b64decode(content[1].data) == PNG_BYTES

--- a/tests/test_image_tool.py
+++ b/tests/test_image_tool.py
@@ -159,6 +159,29 @@ class TestGetImage:
             await handler._handle_get_image_tool("x.model", 7)
 
     @pytest.mark.asyncio
+    async def test_binary_typed_image_fields_still_resolve(self, handler, mock_connection):
+        """odoo.com reports image_128 as type 'binary', self-hosted as 'image'."""
+        mock_connection.fields_get.return_value = {
+            "name": {"type": "char"},
+            "image_512": {"type": "binary"},
+        }
+
+        result = await handler._handle_get_image_tool("product.template", 7)
+
+        assert result["field"] == "image_512"
+
+    @pytest.mark.asyncio
+    async def test_binary_field_is_named_in_the_hint(self, handler, mock_connection):
+        """A model with binary fields but no image_* variant says which to try."""
+        mock_connection.fields_get.return_value = {
+            "name": {"type": "char"},
+            "datas": {"type": "binary"},
+        }
+
+        with pytest.raises(ValidationError, match="binary/image fields on this model: datas"):
+            await handler._handle_get_image_tool("ir.attachment", 7)
+
+    @pytest.mark.asyncio
     async def test_invalid_size_is_refused(self, handler):
         with pytest.raises(ValidationError, match="size must be one of"):
             await handler._handle_get_image_tool("product.template", 7, size=300)


### PR DESCRIPTION
## Why

Nothing this server returns can be looked at. Odoo is full of things that are easier to see than to read (product photos, avatars, logos), and MCP has carried `ImageContent` since its first revision. We just never used it: binary and image fields are filtered out of every read path (`tools/formatting.py`, `formatters.py`, `resources/retrieval.py`) and `tools/binary.py` is upload-only.

This is phase 1 of the visuals plan. The research behind it is written up in `docs/adr/0003-visuals-images-and-mcp-apps.md`.

## What changed

**New tool `get_image`** (`mcp_server_odoo/tools/images.py`, new `ImageToolsMixin`):

- reads an image field and returns a real picture plus one line of context
- `size` (128/256/512/1024/1920, default 512) maps onto Odoo's own stored variants, so there is no server-side resizing and no imaging dependency
- `field_name` overrides the resolution when the caller knows better (e.g. `image_variant_1920`)
- format is sniffed from the bytes, never guessed from the field name; PNG, JPEG, GIF and WebP are returned, anything else is refused with a message naming what was found (a PDF says "PDF")
- read-only, annotated as such, ACL checked like every other tool, capped at 5 MB with an error that names the fix
- `structured_output=False` on purpose: FastMCP would otherwise derive an output schema from the return annotation and ship the same base64 twice, once as `content` and once as `structuredContent`

**ADR 0003** records the plan for the rest: an MCP Apps pilot (`io.modelcontextprotocol/ui`) behind a flag, then aggregation for charts, then write preview and documents. Two findings worth pulling out of it:

- MCP Apps needs no SDK upgrade. `FastMCP.tool(..., meta=...)` and `FastMCP.resource(..., mime_type=..., meta=...)` exist in mcp 1.27.2, our current floor pin, and the official `ext-apps` repo ships a Python example on `mcp.server.fastmcp`. The mcp 2.0 / 2026-07-28 stateless migration is a separate track.
- Clicks inside a future app view are real `tools/call` traffic, so they count against the daily limit. That needs saying out loud in the admin repo before a pilot goes live.

## Tests

25 new tests in `tests/test_image_tool.py`: field resolution and fallback, explicit field, size validation, empty field, missing record, oversized payload, PDF in a binary field, bytes vs str from the transport, auth and ACL failures, plus two that drive the tool through a real `FastMCP` instance to pin the no-output-schema contract.

Full suite: 604 passed, 98 skipped. `ruff check` and `ruff format` clean, `check_max_lines.py` OK.

## Notes for review

- Images cost model tokens on every turn they stay in context. The default is deliberately 512 and the docstring says so.
- One extra tool for every user, self-hosters included. It is read-only and mirrors the existing `set_binary_field` on the write side.
- Non-image binaries (PDF, spreadsheets) are explicitly out of scope here; they want a resource link, not inline bytes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnYFBHx694bxkXstgJxPN8)_