### PR TITLE
release: 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-09-05
+
+Major because the `mcp` dependency moves from 1.x to 2.x: anything installed
+next to `mcp<2` stops resolving, and `create_fastmcp_app` now returns the
+SDK's `MCPServer` rather than `FastMCP`. Tool and resource behaviour is
+unchanged.
+
 ### Changed
 - Moved to the MCP Python SDK 2.x (`mcp>=2.1.1,<3`), which speaks the final
   2026-07-28 protocol: stateless requests with no handshake, and Multi

--- a/mcp_server_odoo/__init__.py
+++ b/mcp_server_odoo/__init__.py
@@ -6,7 +6,7 @@
 # This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """MCP Server for Odoo - Model Context Protocol server for Odoo ERP systems."""
 
-__version__ = "2.4.3"
+__version__ = "3.0.0"
 __author__ = "Andrey Ivanov"
 __license__ = "MPL-2.0"
 

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -41,7 +41,7 @@ logger = get_logger(__name__)
 
 # Server version. Must match __version__ and pyproject.toml; enforced by
 # tests/test_version_consistency.py so it cannot silently drift.
-SERVER_VERSION = "2.4.3"
+SERVER_VERSION = "3.0.0"
 GIT_COMMIT = os.environ.get("GIT_COMMIT", "unknown")
 _BUILD_ORIGIN = "pnl-mcp-7f3a"  # Pantalytics provenance tag
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-server-odoo"
-version = "2.4.3"
+version = "3.0.0"
 description = "AI connector for Odoo ERP -- connect Claude, ChatGPT, and other AI tools to Odoo via MCP (Model Context Protocol)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -24,7 +24,6 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "exceptiongroup", marker = "python_version < '0'" },
     { name = "idna", marker = "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'" },
     { name = "sniffio", marker = "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'" },
     { name = "typing-extensions", marker = "python_full_version == '3.12.*' and sys_platform == 'emscripten'" },
@@ -474,7 +473,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.13' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -631,7 +630,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-odoo"
-version = "2.4.3"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },
@@ -1304,8 +1303,8 @@ name = "uvicorn"
 version = "0.34.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/ad/713be230bcda622eaa35c28f0d328c3675c371238470abdea52417f17a8e/uvicorn-0.34.3.tar.gz", hash = "sha256:35919a9a979d7a59334b6b10e05d77c1d0d574c50e0fc98b8b1a0f165708b55a", size = 76631, upload-time = "2025-06-01T07:48:17.531Z" }


### PR DESCRIPTION
Version bump for the SDK 2.x migration merged in [#125](https://github.com/pantalytics/odoo-mcp-pro/pull/125). Major because the `mcp` dependency moves from 1.x to 2.x: anything installed next to `mcp<2` stops resolving, and `create_fastmcp_app` now returns `MCPServer` rather than `FastMCP`. Tool and resource behaviour is unchanged.

Three version sites plus the changelog and lockfile, as every release here. Tag `v3.0.0` goes on the merge commit; the admin repo pin follows in its own session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116RhvQrqGmZNqKRXf4vmug

---
_Generated by [Claude Code](https://claude.ai/code/session_0116RhvQrqGmZNqKRXf4vmug)_