### PR TITLE
execute_method asks the wizard's question as a form (ADR 0004, phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 
 ## [Unreleased]
 
+### Added
+- `execute_method` asks a wizard's question through MCP's own round trip when
+  the client can show a form (protocol 2026-07-28, `input_required`): the user
+  answers the backorder / register-payment / cancel / reversal form directly,
+  and the retry completes the wizard. Declining it changes nothing and reports
+  `result_kind: declined`. Older clients keep the `followup` dict and the
+  explicit `decision` re-call, unchanged.
+
 ## [3.0.0] - 2026-09-05
 
 Major because the `mcp` dependency moves from 1.x to 2.x: anything installed

--- a/mcp_server_odoo/schemas.py
+++ b/mcp_server_odoo/schemas.py
@@ -212,9 +212,11 @@ class ExecuteMethodResult(BaseModel):
             "Shape of the return value: 'value' (bool/number/string/None), "
             "'records' (list of record ids), 'action' (Odoo returned a wizard or "
             "window action that still needs a follow-up decision), 'completed' "
-            "(a known wizard was driven to completion for you), or 'unsupported' "
-            "(the method needs a follow-up wizard this server has not validated; "
-            "nothing was changed and success is False)"
+            "(a known wizard was driven to completion for you), 'declined' (the "
+            "user declined or cancelled the wizard's form; nothing was changed and "
+            "success is False), or 'unsupported' (the method needs a follow-up "
+            "wizard this server has not validated; nothing was changed and "
+            "success is False)"
         ),
     )
     result: Any = Field(

--- a/mcp_server_odoo/tools/input_required.py
+++ b/mcp_server_odoo/tools/input_required.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+"""Ask a wizard's question through MCP's own round trip (MRTR, 2026-07-28).
+
+Since the 2026-07-28 protocol a tool can answer "I need input first": it returns
+an ``InputRequiredResult`` carrying the question, the client shows the form,
+and the client re-issues the *same* call with the answer in ``input_responses``.
+No stream stays open and any replica can serve the retry, which is exactly
+the two-step ``decision`` / ``followup`` flow in ``methods.py`` -- now spoken
+in the protocol's own words, so the client renders a form instead of the model
+reading a JSON description and calling again.
+
+Older clients cannot receive an ``InputRequiredResult`` at all (the SDK
+rejects it as an invalid ``tools/call`` result for them), and on our stateless
+transport there is no back-channel to ask them mid-call. So the question is
+only asked this way when ``client_can_answer``; everyone else keeps the
+``followup`` dict. See docs/adr/0004-interactive-elements-sdk-v2-and-mcp-apps.md.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from mcp.server.elicitation import render_elicitation_schema
+from mcp.server.mcpserver import Context
+from mcp.types import ElicitRequest, ElicitRequestFormParams, ElicitResult, InputRequiredResult
+from mcp_types.version import is_version_at_least
+
+from .wizards import WizardHandler
+
+INPUT_REQUIRED_VERSION = "2026-07-28"
+"""First protocol revision whose tools/call may return an InputRequiredResult."""
+
+DECISION_KEY = "decision"
+"""Key of the one question we ask; the retry carries the answer under it."""
+
+
+@dataclass(frozen=True)
+class Answer:
+    """What the client brought back on its retry."""
+
+    action: str
+    """``accept``, ``decline`` or ``cancel`` -- the elicitation's own vocabulary."""
+
+    decision: Optional[Dict[str, Any]]
+    """The filled-in form on ``accept``; ``None`` otherwise."""
+
+
+def client_can_answer(ctx: Optional[Context]) -> bool:
+    """True when the client can show a form mid-call and retry with the answer.
+
+    Needs both halves: a protocol that carries ``InputRequiredResult`` and a
+    client that advertised form elicitation. Anything less gets the
+    ``followup`` dict, which every client can act on.
+    """
+    if ctx is None:
+        return False
+    version = ctx.protocol_version
+    if not version or not is_version_at_least(version, INPUT_REQUIRED_VERSION):
+        return False
+    caps = ctx.client_capabilities
+    return bool(caps is not None and caps.elicitation is not None and caps.elicitation.form)
+
+
+def ask_decision(handler: WizardHandler) -> InputRequiredResult:
+    """The wizard's question as a form the client renders.
+
+    The schema is the same primitive-only pydantic model ``followup_descriptor``
+    describes, rendered the way the elicitation spec wants it. No
+    ``request_state``: the retry re-runs the Odoo method, which hands the same
+    wizard back, so there is nothing to remember between the two calls.
+    """
+    return InputRequiredResult(
+        input_requests={
+            DECISION_KEY: ElicitRequest(
+                params=ElicitRequestFormParams(
+                    message=handler.prompt,
+                    requested_schema=render_elicitation_schema(handler.schema),
+                )
+            )
+        }
+    )
+
+
+def answered_decision(ctx: Optional[Context]) -> Optional[Answer]:
+    """The answer the client carried on its retry, or ``None`` on a first call."""
+    if ctx is None or not ctx.input_responses:
+        return None
+    response = ctx.input_responses.get(DECISION_KEY)
+    if not isinstance(response, ElicitResult):
+        return None
+    if response.action == "accept":
+        return Answer("accept", dict(response.content or {}))
+    return Answer(response.action, None)

--- a/mcp_server_odoo/tools/methods.py
+++ b/mcp_server_odoo/tools/methods.py
@@ -13,9 +13,10 @@ stay out of the way.
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
-from mcp.types import ToolAnnotations
+from mcp.server.mcpserver import Context
+from mcp.types import InputRequiredResult, ToolAnnotations
 
 from ..access_control import AccessControlError
 from ..error_handling import ValidationError
@@ -24,6 +25,7 @@ from ..logging_config import perf_logger
 from ..odoo_connection import OdooConnectionError
 from ..schemas import ExecuteMethodResult
 from ._common import _current_sub, logger, run_blocking, validate_access
+from .input_required import answered_decision, ask_decision, client_can_answer
 from .wizards import WizardHandler, followup_descriptor, get_handler
 
 _ACTION_SHAPE_KEYS = ("view_mode", "views", "target", "res_id", "domain")
@@ -91,7 +93,8 @@ class MethodsToolsMixin:
             kwargs: Optional[Dict[str, Any]] = None,
             decision: Optional[Dict[str, Any]] = None,
             connection: Optional[str] = None,
-        ) -> ExecuteMethodResult:
+            ctx: Optional[Context] = None,  # injected by the SDK, never by the model
+        ) -> Union[ExecuteMethodResult, InputRequiredResult]:
             """Call a public method on an Odoo model or recordset.
 
             This is the standard Odoo way to trigger an action that is not plain
@@ -103,8 +106,10 @@ class MethodsToolsMixin:
             delivery that is short on stock asks whether to create a backorder).
             For known wizards this tool finishes them with Odoo's own wizard when
             you pass the answer in `decision`. If you call without a decision, the
-            wizard's fields are returned (`followup`) so you can read them and
-            re-call with `decision` filled in. This two-step flow is stateless: it
+            wizard's question is put to the user as a form when your client can
+            show one (MCP 2026-07-28 input_required); otherwise the wizard's
+            fields are returned (`followup`) so you can read them and re-call
+            with `decision` filled in. Either way the flow is stateless: it
             needs no live back-and-forth with your client.
 
             Args:
@@ -133,9 +138,17 @@ class MethodsToolsMixin:
                 a known wizard was driven to the end for you.
             """
             result = await self._handle_execute_method_tool(
-                model, method, ids, kwargs, decision=decision, connection_selector=connection
+                model,
+                method,
+                ids,
+                kwargs,
+                decision=decision,
+                connection_selector=connection,
+                ctx=ctx,
             )
             self._track_usage(_current_sub.get(), "execute_method")
+            if isinstance(result, InputRequiredResult):
+                return result
             return ExecuteMethodResult(**result)
 
     async def _handle_execute_method_tool(
@@ -146,9 +159,33 @@ class MethodsToolsMixin:
         kwargs: Optional[Dict[str, Any]] = None,
         decision: Optional[Dict[str, Any]] = None,
         connection_selector: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        ctx: Optional[Context] = None,
+    ) -> Union[Dict[str, Any], InputRequiredResult]:
         """Handle execute_method tool request."""
         try:
+            if decision is None:
+                # A retry of the form we asked for (input_required) carries the
+                # answer here; it is the `decision` the caller would have passed.
+                answer = answered_decision(ctx)
+                if answer is not None and answer.decision is None:
+                    verb = "declined" if answer.action == "decline" else "cancelled"
+                    return {
+                        "success": False,
+                        "model": model,
+                        "method": method,
+                        "result_kind": "declined",
+                        "result": None,
+                        "action": None,
+                        "followup": None,
+                        "message": (
+                            f"{model}.{method} was not completed: the user {verb} the "
+                            f"wizard, so nothing was changed."
+                        ),
+                    }
+                if answer is not None:
+                    decision = answer.decision
+            interactive = decision is None and client_can_answer(ctx)
+
             connection, access_controller, sub = await self._get_user_context(
                 connection_selector, writes=True
             )
@@ -193,6 +230,7 @@ class MethodsToolsMixin:
                             model,
                             method,
                             ids or [],
+                            interactive,
                         )
                     # Known method, but it needs a follow-up wizard we have NOT
                     # validated. We refuse rather than guess: an un-vetted
@@ -253,17 +291,18 @@ class MethodsToolsMixin:
         model: str,
         method: str,
         ids: List[int],
-    ) -> Dict[str, Any]:
+        interactive: bool = False,
+    ) -> Union[Dict[str, Any], InputRequiredResult]:
         """Two-step follow-up for a known wizard, stateless by design.
 
-        Mirrors the MCP 2026-07-28 stateless-elicitation shape (SEP-2322): a first
-        call with no answer returns what to fill in (our `followup`, the analogue
-        of `InputRequiredResult.inputRequests`); the caller re-issues the SAME
-        call with the answer (our `decision`, the analogue of `inputResponses`).
+        The MCP 2026-07-28 shape (SEP-2322): a first call with no answer returns
+        what to fill in; the caller re-issues the SAME call with the answer.
         Any replica can serve either call, so this works on stateless HTTP and
-        survives blue-green deploys. When the SDK ships InputRequiredResult we
-        rename `followup`->inputRequests and `decision`->inputResponses; the flow
-        is already this.
+        survives blue-green deploys. With `interactive` (the client speaks
+        2026-07-28 and can show a form) the question goes out as the protocol's
+        own `InputRequiredResult`, and the answer comes back as `decision`
+        through `input_required.answered_decision`; otherwise it is our
+        `followup` dict and the caller re-calls with `decision` by hand.
 
         The discover-vs-complete signal is *presence*, not truthiness:
         - `decision is None`  -> discover (return the fields to fill).
@@ -293,6 +332,10 @@ class MethodsToolsMixin:
             if _classify_result(comp_result) == "action":
                 next_handler = get_handler(comp_result)
                 if next_handler is not None:
+                    # Not asked as a form on purpose: the retry re-runs the
+                    # method, which hands back the FIRST wizard, so an answer to
+                    # the second would be applied to the wrong one. The dict
+                    # says another decision is needed and leaves it there.
                     res_model = comp_result.get("res_model")
                     return {
                         "success": True,
@@ -332,7 +375,10 @@ class MethodsToolsMixin:
                 "message": f"{model}.{method} -> {completion.get('message')} {via}",
             }
 
-        # Discover: return the fields to fill (re-call with `decision` to complete).
+        # Discover: ask the client outright, or return the fields to fill
+        # (re-call with `decision` to complete).
+        if interactive:
+            return ask_decision(handler)
         return {
             "success": True,
             "model": model,

--- a/tests/test_execute_method_input_required.py
+++ b/tests/test_execute_method_input_required.py
@@ -1,0 +1,119 @@
+"""execute_method asks a wizard's question through MCP's own round trip.
+
+Drives a real MCPServer with the real 2.x client, in-process. A client that
+speaks 2026-07-28 and can show a form gets an InputRequiredResult and answers
+it; the retry completes the wizard. A legacy client gets the `followup` dict
+it always got. See docs/adr/0004-interactive-elements-sdk-v2-and-mcp-apps.md.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from mcp.client import Client
+from mcp.types import ElicitResult
+
+from mcp_server_odoo.access_control import AccessController
+from mcp_server_odoo.config import OdooConfig
+from mcp_server_odoo.server import create_fastmcp_app
+from mcp_server_odoo.tools import register_tools
+from mcp_server_odoo.tools.wizards import WIZARD_REGISTRY
+
+BACKORDER_ACTION = {
+    "type": "ir.actions.act_window",
+    "res_model": "stock.backorder.confirmation",
+    "context": {"default_pick_ids": [(4, 5)], "default_show_transfers": False},
+}
+CALL = {"model": "stock.picking", "method": "button_validate", "ids": [5]}
+
+
+def _app(connection):
+    app = create_fastmcp_app()
+    access = Mock(spec=AccessController)
+    config = OdooConfig(url="http://localhost:8069", api_key="k", database="db")
+    register_tools(app, connection, access, config)
+    return app
+
+
+@pytest.fixture
+def connection():
+    conn = Mock()
+    conn.is_authenticated = True
+    conn._base_url = "http://localhost:8069"
+    # The first call returns the wizard; the retry re-runs the method and gets
+    # the same wizard back; completing it answers True.
+    conn.call_method.side_effect = [BACKORDER_ACTION, BACKORDER_ACTION, True]
+    conn.create.return_value = 99
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_form_shown_and_answer_completes_wizard(connection):
+    asked = []
+
+    async def answer(context, params):
+        asked.append(params)
+        return ElicitResult(action="accept", content={"create_backorder": True})
+
+    async with Client(_app(connection), elicitation_callback=answer) as client:
+        result = await client.call_tool("execute_method", CALL)
+
+    assert not result.is_error
+    assert result.structured_content["result_kind"] == "completed"
+    # The form is the wizard's own question and its own schema.
+    (params,) = asked
+    assert params.message == WIZARD_REGISTRY["stock.backorder.confirmation"].prompt
+    assert "create_backorder" in params.requested_schema["properties"]
+    # And the answer drove Odoo's wizard: created, then processed with a backorder.
+    assert connection.create.call_args.args[0] == "stock.backorder.confirmation"
+    assert connection.call_method.call_args.args[:2] == ("stock.backorder.confirmation", "process")
+
+
+@pytest.mark.asyncio
+async def test_declined_form_changes_nothing(connection):
+    async def decline(context, params):
+        return ElicitResult(action="decline")
+
+    async with Client(_app(connection), elicitation_callback=decline) as client:
+        result = await client.call_tool("execute_method", CALL)
+
+    assert result.structured_content["success"] is False
+    assert result.structured_content["result_kind"] == "declined"
+    assert "declined" in result.structured_content["message"]
+    connection.create.assert_not_called()
+    # The retry did not even re-run the Odoo method.
+    assert connection.call_method.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_explicit_decision_skips_the_form(connection):
+    async def never(context, params):  # pragma: no cover - must not be reached
+        raise AssertionError("no form should be shown when a decision is passed")
+
+    # One call, no retry: the method returns the wizard, completing it answers True.
+    connection.call_method.side_effect = [BACKORDER_ACTION, True]
+    async with Client(_app(connection), elicitation_callback=never) as client:
+        result = await client.call_tool(
+            "execute_method", {**CALL, "decision": {"create_backorder": False}}
+        )
+
+    assert result.structured_content["result_kind"] == "completed"
+    assert connection.call_method.call_args.args[:2] == (
+        "stock.backorder.confirmation",
+        "process_cancel_backorder",
+    )
+
+
+@pytest.mark.asyncio
+async def test_legacy_client_gets_followup_dict(connection):
+    async def never(context, params):  # pragma: no cover - must not be reached
+        raise AssertionError("a legacy client cannot receive input_required")
+
+    async with Client(_app(connection), elicitation_callback=never, mode="legacy") as client:
+        result = await client.call_tool("execute_method", CALL)
+
+    assert not result.is_error
+    body = result.structured_content
+    assert body["result_kind"] == "action"
+    assert body["followup"]["wizard"] == "stock.backorder.confirmation"
+    assert "create_backorder" in body["followup"]["decision_fields"]
+    connection.create.assert_not_called()

--- a/tests/test_wizards.py
+++ b/tests/test_wizards.py
@@ -1,8 +1,10 @@
 """Tests for the wizard follow-up layer on execute_method.
 
 Two-step, stateless: a decision either completes the wizard or, when omitted,
-the wizard's fields are returned so the caller re-calls with `decision`. There
-is no elicitation (see docs/adr/0001-stateless-no-elicitation.md).
+the wizard's fields are returned so the caller re-calls with `decision`. A
+client that speaks MCP 2026-07-28 is asked through the protocol's own
+input_required round trip instead; that path is covered in
+tests/test_execute_method_input_required.py (see ADR 0004).
 
 Mock-based: they assert the create + completion call SEQUENCE matches the
 Odoo 19 wizard API. They do NOT prove real Odoo behaviour (no live instance).


### PR DESCRIPTION
Phase 2 of [ADR 0004](docs/adr/0004-interactive-elements-sdk-v2-and-mcp-apps.md); checklist in https://github.com/pantalytics/odoo-mcp-pro/issues/126.

## What

Since MCP 2026-07-28 a tool can return an `InputRequiredResult`: the client shows the form and re-issues the same call with the answer. That is the two-step `decision` / `followup` flow `execute_method` already has, spoken in the protocol's own words, so a capable client (Claude on the new protocol) renders the backorder / register-payment / cancel / reversal form instead of the model reading a JSON description and calling again.

`tools/input_required.py` holds the three pieces:

- `client_can_answer(ctx)`: protocol >= 2026-07-28 **and** form elicitation advertised. Both halves matter: an older client cannot receive the result at all (the SDK rejects it as an invalid `tools/call` result, verified), and our stateless transport has no back-channel to ask it mid-call. Everyone else keeps the `followup` dict.
- `ask_decision(handler)`: the wizard's own prompt and its primitive-only pydantic schema, rendered as an `ElicitRequest`. No `request_state` is minted: the retry re-runs the Odoo method and gets the same wizard back, exactly as the hand-driven two-step does today.
- `answered_decision(ctx)`: the retry's `ElicitResult` read back as the `decision` the caller would have passed. Declining returns `result_kind: declined`, `success: false`, before Odoo is touched again.

`execute_method` gains an SDK-injected `ctx: Optional[Context]`; it stays out of the input schema the model sees (checked). An explicit `decision` still completes without asking. A chained second wizard is deliberately **not** asked as a form: the retry would hand that answer to the first wizard, so it stays the dict that says another decision is needed.

## Verified

- Four new in-process tests over the real 2.x client (`tests/test_execute_method_input_required.py`): form shown with the wizard's prompt and schema and the answer drives Odoo's wizard; declined changes nothing and does not even re-run the method; explicit decision skips the form; a `mode="legacy"` client gets the `followup` dict.
- Full suite 583 passed (579 + 4). `ruff`, `check_max_lines.py`, `ty` clean.

## Not done here

- Verified in Claude against Odoo 19 (backorder and register payment, both round trips). Needs the hosted deployment on 3.x plus this, and a look at which protocol version claude.ai negotiates today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116RhvQrqGmZNqKRXf4vmug

---
_Generated by [Claude Code](https://claude.ai/code/session_0116RhvQrqGmZNqKRXf4vmug)_