### PR TITLE
The one MCP App: register a payment through a form in the chat (ADR 0004, phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 ## [Unreleased]
 
 ### Added
+- `register_payment` tool, the first MCP App (extension
+  `io.modelcontextprotocol/ui`): in a client that renders MCP Apps, Odoo's
+  register-payment wizard appears as a form in the chat with journal, amount,
+  date and memo, and submitting it registers the payment. Clients without
+  Apps get the same tool as a plain `execute_method` call on
+  `account.move.action_register_payment`, with the `followup` dict or the
+  `input_required` form below.
 - `execute_method` asks a wizard's question through MCP's own round trip when
   the client can show a form (protocol 2026-07-28, `input_required`): the user
   answers the backorder / register-payment / cancel / reversal form directly,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ collection time).
 | File | Role |
 |------|------|
 | `server.py` | Factory pattern, `MCPServer` setup, stdio/HTTP runners |
-| `tools/` | MCP tools as mixins on `OdooToolHandler` (crud, query, bulk, binary, messaging, introspection) |
+| `tools/` | MCP tools as mixins on `OdooToolHandler` (crud, query, bulk, binary, messaging, introspection, methods); `apps.py` + `register_payment.html` are the one MCP App, `input_required.py` the 2026-07-28 form round trip |
 | `resources/` | MCP resources (URI-based): handler, retrieval, formatting |
 | `schemas.py` | Pydantic result models |
 | `odoo_json2_connection.py` | JSON/2 client (httpx, Odoo 19+); ORM mixin in `odoo_json2_orm.py` |

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -34,6 +34,7 @@ from .performance import PerformanceManager
 from .resources import register_resources
 from .skills import register_skills
 from .tools import register_tools
+from .tools.apps import odoo_apps
 from .version_detect import detect_api_version
 
 # Set up logging
@@ -79,6 +80,8 @@ def create_fastmcp_app(
         instructions=instructions,
         auth=auth,
         token_verifier=token_verifier,
+        # MCP Apps: advertises the extension and serves our ui:// form(s).
+        extensions=[odoo_apps()],
     )
     # Skill resources — markdown workflow guides, no DB connection needed
     register_skills(app)

--- a/mcp_server_odoo/tools/apps.py
+++ b/mcp_server_odoo/tools/apps.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2025-2026 Pantalytics B.V.
+"""The one MCP App: register a payment through a form in the chat.
+
+MCP Apps (extension ``io.modelcontextprotocol/ui``) lets a tool carry a
+``ui://`` resource -- an HTML document the host renders in a sandboxed iframe
+next to the tool result. This module ships exactly one, on purpose (ADR 0004):
+the register-payment wizard as a real form with journal, amount, date and
+memo, instead of a JSON description the model reads and re-calls with.
+
+The tool is ``register_payment``: ``execute_method`` with the method fixed to
+``action_register_payment`` and the form bound to it. It degrades the way the
+extension spec requires -- a client that did not negotiate Apps gets the same
+``followup`` dict (or, on 2026-07-28 with form elicitation, the
+``input_required`` form of ``input_required.py``), and an explicit
+``decision`` completes it like any other wizard. The HTML lives next to this
+file, bundled in one document with no external origins, so the host's
+default CSP (``connect-src 'none'``) is enough.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+from mcp.server.apps import Apps, client_supports_apps
+from mcp.server.mcpserver import Context
+from mcp.types import InputRequiredResult, ToolAnnotations
+
+from ..schemas import ExecuteMethodResult
+from ._common import _current_sub
+
+REGISTER_PAYMENT_UI = "ui://odoo/register-payment.html"
+"""The form's resource URI; the tool's ``_meta.ui.resourceUri`` points here."""
+
+_HTML = Path(__file__).with_name("register_payment.html")
+
+
+def register_payment_html() -> str:
+    """The bundled form, read from disk each time so a packaged wheel serves it too."""
+    return _HTML.read_text(encoding="utf-8")
+
+
+def odoo_apps() -> Apps:
+    """The Apps extension carrying our ``ui://`` resources.
+
+    Passed to ``MCPServer(extensions=[...])`` by ``create_fastmcp_app``; that
+    is what advertises the capability and serves the resource. The tool
+    itself is bound by the handler (``RegisterPaymentToolsMixin``), which
+    needs the Odoo connection the app does not have at construction time.
+    """
+    apps = Apps()
+    apps.add_html_resource(
+        REGISTER_PAYMENT_UI,
+        register_payment_html(),
+        title="Register payment",
+        description="Form for Odoo's register-payment wizard (account.payment.register).",
+    )
+    return apps
+
+
+class RegisterPaymentToolsMixin:
+    """``register_payment``: the wizard behind ``account.move.action_register_payment``."""
+
+    def _register_payment_tools(self):
+        """Register the UI-bound register_payment tool."""
+
+        @self.tool(  # type: ignore[attr-defined]
+            title="Register Payment (form)",
+            annotations=ToolAnnotations(
+                read_only_hint=False,
+                destructive_hint=False,
+                idempotent_hint=False,
+                open_world_hint=True,
+            ),
+            meta={"ui": {"resourceUri": REGISTER_PAYMENT_UI}},
+        )
+        async def register_payment(
+            model: str,
+            ids: List[int],
+            decision: Optional[Dict[str, Any]] = None,
+            connection: Optional[str] = None,
+            ctx: Optional[Context] = None,  # injected by the SDK, never by the model
+        ) -> Union[ExecuteMethodResult, InputRequiredResult]:
+            """Register a payment on posted invoices or bills, through a form.
+
+            Runs Odoo's own register-payment wizard (`account.move.
+            action_register_payment`). Prefer this over `execute_method` for
+            payments: in a client that supports MCP Apps the user gets a form
+            with journal, amount, date and memo right in the chat and submits
+            it there; the result comes back to you as usual. Elsewhere it
+            behaves exactly like `execute_method`: call without `decision` to
+            see the wizard's fields (`followup`), or pass `decision={}` to
+            accept Odoo's defaults (full residual, today, default journal).
+
+            Args:
+                model: 'account.move' for invoices and bills.
+                ids: Ids of the posted invoices/bills to pay.
+                decision: The wizard's answer: {"journal_id": 7, "amount": 100.0,
+                    "payment_date": "2026-09-05", "communication": "..."}, any
+                    subset, or {} for Odoo's defaults. Omit to ask.
+                connection: Optional. Target a specific Odoo connection by the
+                    id from server_info's `connections` list. Hosted
+                    multi-tenant only.
+
+            Returns:
+                The same shape as `execute_method`: 'completed' once the payment
+                is registered, 'action' with `followup` while the wizard still
+                needs an answer, 'declined' when the user cancelled the form.
+            """
+            # When the host renders our form, the answer arrives through the
+            # form's own tools/call, so the wizard must come back as the dict the
+            # form reads -- not as an input_required round trip the form never
+            # sees. Dropping ctx is what keeps input_required.py out of it.
+            result = await self._handle_execute_method_tool(  # type: ignore[attr-defined]
+                model,
+                "action_register_payment",
+                ids,
+                None,
+                decision=decision,
+                connection_selector=connection,
+                ctx=None if ctx is not None and client_supports_apps(ctx) else ctx,
+            )
+            self._track_usage(_current_sub.get(), "register_payment")  # type: ignore[attr-defined]
+            if isinstance(result, InputRequiredResult):
+                return result
+            return ExecuteMethodResult(**result)

--- a/mcp_server_odoo/tools/handler.py
+++ b/mcp_server_odoo/tools/handler.py
@@ -22,6 +22,7 @@ from ..config import OdooConfig
 from ..connection_protocol import OdooConnectionProtocol
 from ..error_handling import ValidationError, as_tool_error
 from ._common import _current_sub, logger
+from .apps import RegisterPaymentToolsMixin
 from .binary import BinaryToolsMixin
 from .bulk import BulkToolsMixin
 from .crud import CrudToolsMixin
@@ -41,6 +42,7 @@ class OdooToolHandler(
     BinaryToolsMixin,
     MessagingToolsMixin,
     MethodsToolsMixin,
+    RegisterPaymentToolsMixin,
 ):
     """Handles MCP tool requests for Odoo operations."""
 
@@ -131,6 +133,7 @@ class OdooToolHandler(
         self._register_binary_tools()
         self._register_messaging_tools()
         self._register_methods_tools()
+        self._register_payment_tools()
 
 
 def register_tools(

--- a/mcp_server_odoo/tools/register_payment.html
+++ b/mcp_server_odoo/tools/register_payment.html
@@ -1,0 +1,194 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Register payment</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #ffffff; --fg: #1f2328; --muted: #656d76; --line: #d0d7de;
+    --accent: #5b58d8; --accent-fg: #ffffff; --ok-bg: #eaf7ee; --ok-fg: #1a7f37;
+    --err-bg: #fdecea; --err-fg: #b42318; --field-bg: #ffffff;
+  }
+  @media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) {
+    --bg: #0d1117; --fg: #e6edf3; --muted: #8b949e; --line: #30363d;
+    --ok-bg: #12261a; --ok-fg: #3fb950; --err-bg: #2d1416; --err-fg: #f85149; --field-bg: #161b22;
+  } }
+  :root[data-theme="dark"] {
+    --bg: #0d1117; --fg: #e6edf3; --muted: #8b949e; --line: #30363d;
+    --ok-bg: #12261a; --ok-fg: #3fb950; --err-bg: #2d1416; --err-fg: #f85149; --field-bg: #161b22;
+  }
+  html, body { margin: 0; background: var(--bg); color: var(--fg);
+    font: 14px/1.45 system-ui, -apple-system, "Segoe UI", sans-serif; }
+  main { padding: 16px; max-width: 520px; }
+  h1 { font-size: 16px; margin: 0 0 4px; }
+  p { margin: 0 0 12px; }
+  .muted { color: var(--muted); }
+  form { display: grid; gap: 10px; }
+  label { display: grid; gap: 4px; font-weight: 600; }
+  label small { font-weight: 400; color: var(--muted); }
+  input { padding: 8px 10px; border: 1px solid var(--line); border-radius: 6px;
+    background: var(--field-bg); color: var(--fg); font: inherit; }
+  input:focus { outline: 2px solid var(--accent); outline-offset: 1px; }
+  .row { display: flex; gap: 8px; align-items: center; margin-top: 4px; }
+  button { padding: 8px 14px; border-radius: 6px; border: 1px solid var(--line);
+    background: var(--field-bg); color: var(--fg); font: inherit; cursor: pointer; }
+  button.primary { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
+  button[disabled] { opacity: .6; cursor: default; }
+  .card { padding: 12px 14px; border-radius: 8px; border: 1px solid var(--line); }
+  .ok { background: var(--ok-bg); color: var(--ok-fg); border-color: transparent; }
+  .err { background: var(--err-bg); color: var(--err-fg); border-color: transparent; }
+  code { font-size: 12px; }
+</style>
+</head>
+<body>
+<main id="root"><p class="muted">Waiting for Odoo…</p></main>
+<script>
+(function () {
+  "use strict";
+  // Minimal MCP Apps client: JSON-RPC 2.0 over postMessage to the host.
+  // See https://modelcontextprotocol.io/extensions/apps/overview
+  var nextId = 1, pending = {}, host = null, toolArgs = null, submitting = false;
+  var root = document.getElementById("root");
+
+  function post(msg) { window.parent.postMessage(msg, "*"); }
+  function request(method, params) {
+    var id = nextId++;
+    return new Promise(function (resolve, reject) {
+      pending[id] = { resolve: resolve, reject: reject };
+      post({ jsonrpc: "2.0", id: id, method: method, params: params || {} });
+    });
+  }
+  function notify(method, params) { post({ jsonrpc: "2.0", method: method, params: params || {} }); }
+
+  window.addEventListener("message", function (ev) {
+    var m = ev.data;
+    if (!m || m.jsonrpc !== "2.0") return;
+    if (m.id !== undefined && m.method === undefined) {           // a response to us
+      var p = pending[m.id]; if (!p) return; delete pending[m.id];
+      if (m.error) p.reject(m.error); else p.resolve(m.result);
+      return;
+    }
+    if (m.method === "ui/notifications/tool-input") { toolArgs = m.params && m.params.arguments || {}; }
+    else if (m.method === "ui/notifications/tool-result") { onToolResult(m.params || {}); }
+    else if (m.method === "ui/notifications/tool-cancelled") { show(card("err", "Cancelled: " + ((m.params || {}).reason || ""))); }
+    else if (m.method === "ui/notifications/host-context-changed") { applyContext(m.params || {}); }
+    else if (m.id !== undefined) { post({ jsonrpc: "2.0", id: m.id, result: {} }); }  // unknown request: answer, never hang
+  });
+
+  function applyContext(ctx) {
+    if (!ctx) return;
+    if (ctx.theme) document.documentElement.setAttribute("data-theme", ctx.theme);
+    var vars = ctx.styles && ctx.styles.variables;
+    if (vars) for (var k in vars) if (k.indexOf("--") === 0) document.documentElement.style.setProperty(k, vars[k]);
+  }
+  function resize() {
+    var h = document.documentElement.scrollHeight, w = document.documentElement.scrollWidth;
+    notify("ui/notifications/size-changed", { width: w, height: h });
+  }
+  function show(node) { root.innerHTML = ""; root.appendChild(node); requestAnimationFrame(resize); }
+  function el(tag, attrs, children) {
+    var n = document.createElement(tag);
+    for (var k in (attrs || {})) { if (k === "text") n.textContent = attrs[k]; else n.setAttribute(k, attrs[k]); }
+    (children || []).forEach(function (c) { n.appendChild(c); });
+    return n;
+  }
+  function card(kind, text) { return el("div", { "class": "card " + kind, text: text }); }
+
+  function structured(params) {
+    if (params.structuredContent) return params.structuredContent;
+    var text = ((params.content || []).filter(function (c) { return c.type === "text"; })[0] || {}).text;
+    try { return text ? JSON.parse(text) : null; } catch (e) { return { message: text }; }
+  }
+
+  function onToolResult(params) {
+    if (params.isError) { show(card("err", (((params.content || [])[0]) || {}).text || "The call failed.")); return; }
+    var r = structured(params); if (!r) { show(card("err", "No result received.")); return; }
+    if (r.result_kind === "action" && r.followup && r.followup.wizard === "account.payment.register") { renderForm(r); return; }
+    renderOutcome(r);
+  }
+
+  function renderOutcome(r) {
+    var kind = r.result_kind === "completed" ? "ok" : (r.success === false ? "err" : "");
+    var box = el("div", { "class": "card " + kind }, [ el("p", { text: r.message || (kind === "ok" ? "Done." : "Nothing changed.") }) ]);
+    if (r.result_kind === "completed" && r.result && typeof r.result === "object") {
+      box.appendChild(el("p", { "class": "muted", text: "Odoo returned: " + JSON.stringify(r.result).slice(0, 200) }));
+    }
+    show(box);
+  }
+
+  function field(name, label, hint, type, extra) {
+    var input = el("input", { name: name, type: type || "text", placeholder: "Odoo's default" });
+    if (extra) for (var k in extra) input.setAttribute(k, extra[k]);
+    return el("label", {}, [ el("span", { text: label }), el("small", { text: hint }), input ]);
+  }
+
+  function renderForm(r) {
+    var fields = (r.followup && r.followup.decision_fields) || {};
+    var form = el("form", {}, [
+      el("h1", { text: "Register payment" }),
+      el("p", { "class": "muted", text: (r.message || "").replace(/ Re-call with decision.*$/, "") }),
+      el("p", { "class": "muted", text: "Leave a field empty to take Odoo's default." }),
+      field("journal_id", "Journal", (fields.journal_id || {}).description || "Payment journal id", "number", { min: "1", step: "1" }),
+      field("amount", "Amount", (fields.amount || {}).description || "Amount to register", "number", { min: "0", step: "0.01" }),
+      field("payment_date", "Payment date", (fields.payment_date || {}).description || "YYYY-MM-DD", "date"),
+      field("communication", "Memo", (fields.communication || {}).description || "Memo on the payment", "text")
+    ]);
+    // type=button, not submit: a sandbox without allow-forms (the host's
+    // default) blocks native submission before any submit event fires.
+    var submit = el("button", { type: "button", "class": "primary", text: "Register payment" });
+    var status = el("span", { "class": "muted" });
+    form.appendChild(el("div", { "class": "row" }, [ submit, status ]));
+    var canCall = !!(host && host.hostCapabilities && host.hostCapabilities.serverTools);
+    if (!canCall) {
+      submit.disabled = true;
+      status.textContent = "This client cannot submit from here; ask the assistant to pass the decision.";
+    }
+    function onSubmit() {
+      if (submitting || !canCall) return;
+      var fd = new FormData(form), decision = {};
+      var j = fd.get("journal_id"), a = fd.get("amount"), d = fd.get("payment_date"), c = fd.get("communication");
+      if (j) decision.journal_id = parseInt(j, 10);
+      if (a) decision.amount = parseFloat(a);
+      if (d) decision.payment_date = d;
+      if (c) decision.communication = c;
+      var args = { model: (toolArgs && toolArgs.model) || r.model, ids: (toolArgs && toolArgs.ids) || [], decision: decision };
+      if (toolArgs && toolArgs.connection) args.connection = toolArgs.connection;
+      submitting = true; submit.disabled = true; status.textContent = "Registering…";
+      request("tools/call", { name: "register_payment", arguments: args }).then(function (res) {
+        submitting = false;
+        var out = res.isError ? null : structured(res);
+        if (!out) { status.textContent = ""; submit.disabled = false; show(card("err", (((res.content || [])[0]) || {}).text || "The call failed.")); return; }
+        renderOutcome(out);
+        // Tell the model what happened, so the conversation can carry on from it.
+        request("ui/update-model-context", {
+          content: [{ type: "text", text: out.message || "Payment registered." }],
+          structuredContent: out
+        }).catch(function () {});
+      }).catch(function (err) {
+        submitting = false; submit.disabled = false; status.textContent = "";
+        show(card("err", (err && err.message) || "The call failed."));
+      });
+    }
+    submit.addEventListener("click", onSubmit);
+    form.addEventListener("keydown", function (ev) { if (ev.key === "Enter") { ev.preventDefault(); onSubmit(); } });
+    show(form);
+  }
+
+  request("ui/initialize", {
+    protocolVersion: "2026-01-26",
+    clientInfo: { name: "odoo-mcp-pro register-payment", version: "1" },
+    appCapabilities: {}
+  }).then(function (result) {
+    host = result || {};
+    applyContext(host.hostContext);
+    notify("ui/notifications/initialized", {});
+    show(el("p", { "class": "muted", text: "Waiting for Odoo…" }));
+  }).catch(function (err) {
+    show(card("err", "Could not connect to the host: " + ((err && err.message) || "")));
+  });
+})();
+</script>
+</body>
+</html>

--- a/tests/test_register_payment_app.py
+++ b/tests/test_register_payment_app.py
@@ -1,0 +1,112 @@
+"""The one MCP App: register_payment carries a ui:// form (ADR 0004, phase 3).
+
+Drives a real MCPServer with the real 2.x client, in-process. The resource is
+served under the Apps MIME type, the tool binds it, and the fallbacks hold:
+a client that negotiated Apps gets the followup dict the form reads (never an
+input_required round trip it cannot see); a client without Apps but with form
+elicitation gets that round trip; an explicit decision completes outright.
+"""
+
+import re
+from unittest.mock import Mock
+
+import pytest
+from mcp.client import Client, advertise
+from mcp.server.apps import APP_MIME_TYPE, EXTENSION_ID
+from mcp.types import ElicitResult
+
+from mcp_server_odoo.access_control import AccessController
+from mcp_server_odoo.config import OdooConfig
+from mcp_server_odoo.server import create_fastmcp_app
+from mcp_server_odoo.tools import register_tools
+from mcp_server_odoo.tools.apps import REGISTER_PAYMENT_UI, register_payment_html
+
+PAYMENT_ACTION = {
+    "type": "ir.actions.act_window",
+    "res_model": "account.payment.register",
+    "context": {},
+}
+CALL = {"model": "account.move", "ids": [12]}
+APPS_CLIENT = [advertise(EXTENSION_ID, {"mimeTypes": [APP_MIME_TYPE]})]
+
+
+def _app(connection):
+    app = create_fastmcp_app()
+    config = OdooConfig(url="http://localhost:8069", api_key="k", database="db")
+    register_tools(app, connection, Mock(spec=AccessController), config)
+    return app
+
+
+@pytest.fixture
+def connection():
+    conn = Mock()
+    conn.is_authenticated = True
+    conn._base_url = "http://localhost:8069"
+    conn.call_method.side_effect = [PAYMENT_ACTION, PAYMENT_ACTION, {"payment": 1}]
+    conn.create.return_value = 77
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_form_resource_is_served_and_bound(connection):
+    async with Client(_app(connection), extensions=APPS_CLIENT) as client:
+        tool = next(t for t in (await client.list_tools()).tools if t.name == "register_payment")
+        assert tool.meta["ui"]["resourceUri"] == REGISTER_PAYMENT_UI
+        assert "ctx" not in tool.input_schema["properties"]
+        listed = {r.uri: r.mime_type for r in (await client.list_resources()).resources}
+        assert listed[REGISTER_PAYMENT_UI] == APP_MIME_TYPE
+        read = (await client.read_resource(REGISTER_PAYMENT_UI)).contents[0]
+        assert read.mime_type == APP_MIME_TYPE
+        assert "ui/initialize" in read.text
+        assert read.text == register_payment_html()
+
+
+def test_form_needs_no_external_origin():
+    """Bundled on purpose: the host's default CSP allows nothing else."""
+    html = register_payment_html()
+    assert not re.search(r"""(src|href)\s*=\s*["']https?://""", html)
+    assert "fetch(" not in html and "XMLHttpRequest" not in html and "import(" not in html
+
+
+@pytest.mark.asyncio
+async def test_apps_client_gets_the_dict_the_form_reads(connection):
+    async def never(context, params):  # pragma: no cover - must not be reached
+        raise AssertionError("an Apps client must not get an input_required form")
+
+    async with Client(
+        _app(connection), extensions=APPS_CLIENT, elicitation_callback=never
+    ) as client:
+        result = await client.call_tool("register_payment", CALL)
+
+    body = result.structured_content
+    assert body["result_kind"] == "action"
+    assert body["followup"]["wizard"] == "account.payment.register"
+    assert set(body["followup"]["decision_fields"]) >= {"journal_id", "amount", "payment_date"}
+    connection.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_client_without_apps_falls_back_to_input_required(connection):
+    async def accept_defaults(context, params):
+        return ElicitResult(action="accept", content={})
+
+    async with Client(_app(connection), elicitation_callback=accept_defaults) as client:
+        result = await client.call_tool("register_payment", CALL)
+
+    assert result.structured_content["result_kind"] == "completed"
+    assert connection.create.call_args.args[0] == "account.payment.register"
+
+
+@pytest.mark.asyncio
+async def test_decision_from_the_form_completes(connection):
+    connection.call_method.side_effect = [PAYMENT_ACTION, {"payment": 1}]
+    async with Client(_app(connection), extensions=APPS_CLIENT) as client:
+        result = await client.call_tool(
+            "register_payment", {**CALL, "decision": {"journal_id": 7, "amount": 100.0}}
+        )
+
+    body = result.structured_content
+    assert body["result_kind"] == "completed"
+    assert body["method"] == "action_register_payment"
+    _, vals = connection.create.call_args.args[:2]
+    assert vals["journal_id"] == 7 and vals["amount"] == 100.0


### PR DESCRIPTION
Phase 3 of [ADR 0004](docs/adr/0004-interactive-elements-sdk-v2-and-mcp-apps.md); checklist in https://github.com/pantalytics/odoo-mcp-pro/issues/126. Exactly one app, as the ADR says.

## What

A new tool, `register_payment`: `execute_method` with the method fixed to `account.move.action_register_payment`, bound through `_meta.ui.resourceUri` to `ui://odoo/register-payment.html`. In a client that renders MCP Apps (Claude, Claude Desktop) the wizard appears as a form with journal, amount, date and memo; submitting it calls `register_payment` back from inside the iframe with the `decision`, shows the outcome, and hands it to the model through `ui/update-model-context`.

- `tools/apps.py`: `odoo_apps()` is the SDK's `Apps` extension holding the resource; `create_fastmcp_app` passes it as `extensions=[...]`, which is what advertises the capability and serves the HTML under `text/html;profile=mcp-app`. `RegisterPaymentToolsMixin` binds the tool. The admin package gets both through the seam it already uses.
- **Degrade** follows the extension's own rule: a client that negotiated Apps gets the `followup` dict the form reads (`ctx` is dropped so the phase 2 `input_required` round trip stays out of it, since the form cannot see one); a client that did not gets exactly `execute_method`'s behaviour, the dict or the 2026-07-28 form.
- `tools/register_payment.html`: one document, no external origin, so the host's default CSP (`connect-src 'none'`) is enough. Speaks the apps dialect over `postMessage` directly (`ui/initialize`, `tool-input`, `tool-result`, `tools/call`, `ui/update-model-context`, `size-changed`) and follows the host's theme. No TypeScript toolchain, no build step.
- The submit is a click handler on a `type=button` on purpose: a sandbox without `allow-forms`, the host default, blocks native form submission before any `submit` event fires. Found in Chromium, not guessed.

## Verified

- End to end in headless Chromium against a fake host: handshake, dark theme applied, form rendered from the `followup`, submit sent `tools/call register_payment` with `{journal_id: 7, amount: 100.5, payment_date, communication}` and the model/ids the host passed in, outcome card shown, `update-model-context` sent, three `size-changed` notifications, no console errors. Screenshots below.
- Five in-process tests over the real 2.x client (`tests/test_register_payment_app.py`): resource served and bound, no external origin in the HTML, Apps client gets the dict, non-Apps client falls back to the `input_required` form, a decision completes through `action_create_payments`.
- Full suite 588 passed. `ruff`, `check_max_lines.py`, `ty` clean. `uv build` confirms the HTML ships in the wheel.

## Not done here

- Tried in Claude with a real customer on Odoo 19. That is the spike's actual question, and it needs the hosted deployment on this. The decision to widen to the other four wizards, or stop, follows from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116RhvQrqGmZNqKRXf4vmug

---
_Generated by [Claude Code](https://claude.ai/code/session_0116RhvQrqGmZNqKRXf4vmug)_