### PR TITLE
release: 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-09-05
+
+Interactive elements, per ADR 0004: the wizard question as a form. Both
+additions degrade to exactly what 3.0.0 did for a client that cannot show one.
+
 ### Added
 - `register_payment` tool, the first MCP App (extension
   `io.modelcontextprotocol/ui`): in a client that renders MCP Apps, Odoo's

--- a/mcp_server_odoo/__init__.py
+++ b/mcp_server_odoo/__init__.py
@@ -6,7 +6,7 @@
 # This file stays under the Mozilla Public License 2.0; see LICENSE.MPL-2.0.
 """MCP Server for Odoo - Model Context Protocol server for Odoo ERP systems."""
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 __author__ = "Andrey Ivanov"
 __license__ = "MPL-2.0"
 

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -42,7 +42,7 @@ logger = get_logger(__name__)
 
 # Server version. Must match __version__ and pyproject.toml; enforced by
 # tests/test_version_consistency.py so it cannot silently drift.
-SERVER_VERSION = "3.0.0"
+SERVER_VERSION = "3.1.0"
 GIT_COMMIT = os.environ.get("GIT_COMMIT", "unknown")
 _BUILD_ORIGIN = "pnl-mcp-7f3a"  # Pantalytics provenance tag
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-server-odoo"
-version = "3.0.0"
+version = "3.1.0"
 description = "AI connector for Odoo ERP -- connect Claude, ChatGPT, and other AI tools to Odoo via MCP (Model Context Protocol)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -630,7 +630,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-odoo"
-version = "3.0.0"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
Version bump covering everything ADR 0004 landed after 3.0.0: the 2026-07-28 `input_required` form on `execute_method` ([#128](https://github.com/pantalytics/odoo-mcp-pro/pull/128)) and the register-payment MCP App ([#129](https://github.com/pantalytics/odoo-mcp-pro/pull/129)). Minor, not major: both degrade to exactly what 3.0.0 did for a client that cannot show a form.

Three version sites plus the changelog and lockfile. Tag `v3.1.0` goes on the merge commit; the admin repo pins that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116RhvQrqGmZNqKRXf4vmug

---
_Generated by [Claude Code](https://claude.ai/code/session_0116RhvQrqGmZNqKRXf4vmug)_