### PR TITLE
feat(errors): suggest the real field names when Odoo rejects one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ management UI, admin dashboard, deploy infrastructure) live in the proprietary
 
 ## [Unreleased]
 
+### Changed
+- An "Invalid field" error from Odoo now carries the model's real field names
+  back to the caller. Odoo names the field it rejected and stops there, so the
+  next attempt was no better informed than the first. The error now suggests
+  the closest matching fields and points at `odoo://{model}/fields`, which
+  turns a second round trip into a correction in the same turn.
+
 ## [3.1.0] - 2026-09-05
 
 Interactive elements, per ADR 0004: the wizard question as a form. Both

--- a/mcp_server_odoo/field_hints.py
+++ b/mcp_server_odoo/field_hints.py
@@ -1,0 +1,122 @@
+"""Turn Odoo's "Invalid field" errors into something the AI can act on.
+
+Odoo answers a bad field name with the name it rejected and nothing else:
+``Invalid field 'x_partner_ref' on model 'res.partner'``. The caller learns
+that its guess was wrong but not what the alternatives are, so the next guess
+is no better informed than the first. In production this is the single largest
+failure class on the server, and ``read`` accounts for most of it.
+
+This module reads the rejected name out of the message and matches it against
+the model's real fields, so the error can carry a suggestion back. The work is
+pure string handling; fetching the field list is the caller's job, because only
+the caller knows whether it can afford the round trip (in practice it is cached).
+"""
+
+import difflib
+import re
+from typing import Callable, Iterable, List, Optional
+
+# How many alternatives to offer. Enough to cover a near miss and a plausible
+# second reading, few enough that the AI does not start shopping.
+MAX_SUGGESTIONS = 3
+
+# Below this ratio the "suggestion" is noise. difflib scores a shared prefix
+# generously, so 'x' would otherwise pull in every field starting with x.
+MIN_RATIO = 0.6
+
+# Odoo phrases this differently per version and per code path. Seen in prod:
+#   Invalid field 'x_foo' on model 'res.partner'
+#   Invalid field 'x_foo' on 'res.partner'
+#   Invalid field 'x_foo' in leaf ('x_foo', '=', 1)
+#   Unknown field 'x_foo' in domain
+#   Invalid field partner_id.x_foo in condition ('partner_id.x_foo', '=', 1)
+# The name is quoted in most but not all of them, hence the optional quote.
+_INVALID_FIELD_RE = re.compile(
+    r"\b(?:invalid|unknown)\s+field\s+['\"]?([a-zA-Z_][A-Za-z0-9_.]*)['\"]?",
+    re.IGNORECASE,
+)
+# The other shape: "Field 'x_foo' does not exist" / "Field x_foo does not exist".
+_MISSING_FIELD_RE = re.compile(
+    r"\bfield\s+['\"]?([a-zA-Z_][A-Za-z0-9_.]*)['\"]?\s+does\s+not\s+exist",
+    re.IGNORECASE,
+)
+
+
+def extract_invalid_field(message: str) -> Optional[str]:
+    """Return the field name Odoo rejected, or None if this is another error.
+
+    A dotted path (``partner_id.x_foo``) comes back whole; splitting it is
+    ``suggest_fields``' problem, since only the first segment lives on the
+    model we have the field list for.
+    """
+    if not message:
+        return None
+    for pattern in (_INVALID_FIELD_RE, _MISSING_FIELD_RE):
+        match = pattern.search(message)
+        if match:
+            return match.group(1)
+    return None
+
+
+def suggest_fields(field: str, known_fields: Iterable[str]) -> List[str]:
+    """Rank the model's real fields by closeness to the rejected name.
+
+    Only the first segment of a dotted path is matched: in
+    ``partner_id.x_foo`` the part that has to exist on THIS model is
+    ``partner_id``, and a suggestion for ``x_foo`` would point at the wrong
+    model entirely.
+    """
+    if not field:
+        return []
+    head = field.split(".", 1)[0]
+    candidates = [f for f in known_fields if f]
+    if not candidates:
+        return []
+    return difflib.get_close_matches(head, candidates, n=MAX_SUGGESTIONS, cutoff=MIN_RATIO)
+
+
+def field_hint(message: str, model: str, known_fields: Iterable[str]) -> Optional[str]:
+    """Build the sentence to append to an invalid-field error, or None.
+
+    None means "leave the message alone": either it is not a field error, or we
+    have nothing useful to add and a vaguer error is worse than a short one.
+    """
+    field = extract_invalid_field(message)
+    if field is None:
+        return None
+    fields = sorted(f for f in known_fields if f)
+    if not fields:
+        return None
+    matches = suggest_fields(field, fields)
+    if matches:
+        return f"Did you mean: {', '.join(matches)}? Full list: odoo://{model}/fields"
+    return f"{model} has {len(fields)} fields, none close to '{field}'. Read odoo://{model}/fields for the list."
+
+
+def with_field_hint(
+    message: str,
+    model: str,
+    method: str,
+    fields_getter: Callable[[str], Iterable[str]],
+) -> str:
+    """Append the hint to an error message, or hand it back untouched.
+
+    ``fields_getter`` is the connection's own ``fields_get``, passed in rather
+    than imported so this module stays free of transport concerns and both the
+    XML-RPC and JSON/2 layers can share one implementation. It is called only
+    once the message is known to be a field error, so the round trip is paid
+    on the failure path only, and in practice it is served from the field cache.
+
+    Best effort throughout: anything that goes wrong here returns the original
+    message, because a diagnostic must never replace the error it describes.
+    """
+    if method == "fields_get":
+        return message  # would recurse into the call that just failed
+    if extract_invalid_field(message) is None:
+        return message
+    try:
+        known = fields_getter(model)
+        hint = field_hint(message, model, known)
+    except Exception:
+        return message
+    return f"{message} {hint}" if hint else message

--- a/mcp_server_odoo/odoo_connection/orm.py
+++ b/mcp_server_odoo/odoo_connection/orm.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from ..error_sanitizer import ErrorSanitizer
 from ..exceptions import OdooConnectionError, OdooTimeoutError
+from ..field_hints import with_field_hint
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +118,9 @@ class OdooConnectionOrmMixin:
             logger.error(f"XML-RPC fault during {method} on {model}: {e}")
             # Sanitize the fault string before exposing to user
             sanitized_message = ErrorSanitizer.sanitize_xmlrpc_fault(e.faultString)
+            sanitized_message = with_field_hint(
+                sanitized_message, model, method, lambda m: self.fields_get(m).keys()
+            )
             raise OdooConnectionError(f"Operation failed: {sanitized_message}") from e
         except socket.timeout:
             logger.error(f"Timeout during {method} on {model}")

--- a/mcp_server_odoo/odoo_json2_connection.py
+++ b/mcp_server_odoo/odoo_json2_connection.py
@@ -19,6 +19,7 @@ from curl_cffi.requests.errors import RequestsError
 from .config import OdooConfig
 from .error_sanitizer import ErrorSanitizer
 from .exceptions import OdooConnectionError, OdooTimeoutError  # noqa: F401
+from .field_hints import with_field_hint
 from .odoo_json2_orm import Json2OrmMixin
 
 logger = logging.getLogger(__name__)
@@ -137,6 +138,8 @@ class OdooJSON2Connection(Json2OrmMixin):
 
         # Parse error body
         error_msg = self._parse_error_response(response)
+        # A rejected field name is useless on its own; hand back the real ones.
+        error_msg = with_field_hint(error_msg, model, method, lambda m: self.fields_get(m).keys())
 
         if response.status_code == 401:
             raise OdooConnectionError(f"Authentication failed: {error_msg}")

--- a/tests/test_field_hints.py
+++ b/tests/test_field_hints.py
@@ -1,0 +1,163 @@
+"""Tests for the invalid-field hint.
+
+The message shapes below are the ones seen in production, recovered from the
+failure corpus: Odoo phrases the same rejection at least five different ways
+depending on version and code path, so the parser is tested against all of them
+rather than against one idealised form.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_server_odoo.field_hints import (
+    extract_invalid_field,
+    field_hint,
+    suggest_fields,
+    with_field_hint,
+)
+
+PARTNER_FIELDS = ["id", "name", "ref", "parent_id", "partner_id", "email", "country_id"]
+
+
+class TestExtractInvalidField:
+    @pytest.mark.parametrize(
+        "message,expected",
+        [
+            ("Invalid field 'x_foo' on model 'res.partner'", "x_foo"),
+            ("Invalid field 'x_foo' on 'res.partner'", "x_foo"),
+            ("Invalid field 'x_foo' in leaf ('x_foo', '=', 1)", "x_foo"),
+            ("Unknown field 'x_foo' in domain", "x_foo"),
+            ("Invalid field x_foo in request", "x_foo"),
+            ("Field 'x_foo' does not exist", "x_foo"),
+            ("Invalid field partner_id.x_foo in condition", "partner_id.x_foo"),
+        ],
+    )
+    def test_recognises_odoo_phrasings(self, message, expected):
+        assert extract_invalid_field(message) == expected
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "",
+            "Access denied: You are not allowed to access res.partner records",
+            "Operation failed: Request-sent",
+            "Record ID 42 not found",
+        ],
+    )
+    def test_leaves_other_errors_alone(self, message):
+        assert extract_invalid_field(message) is None
+
+
+class TestSuggestFields:
+    def test_near_miss_is_suggested(self):
+        assert "ref" in suggest_fields("refs", PARTNER_FIELDS)
+
+    def test_dotted_path_matches_on_the_first_segment(self):
+        """In partnr_id.x_foo only the head has to exist on THIS model.
+
+        Matching the tail would suggest fields of a different model entirely,
+        so the tail must not influence the result at all.
+        """
+        assert suggest_fields("partnr_id.x_foo", PARTNER_FIELDS)[0] == "partner_id"
+        assert suggest_fields("partnr_id.x_foo", PARTNER_FIELDS) == suggest_fields(
+            "partnr_id.something_else", PARTNER_FIELDS
+        )
+
+    def test_nothing_close_returns_nothing(self):
+        assert suggest_fields("zzzzzzzz", PARTNER_FIELDS) == []
+
+    def test_no_known_fields_returns_nothing(self):
+        assert suggest_fields("ref", []) == []
+
+
+class TestFieldHint:
+    def test_hint_names_the_alternatives(self):
+        hint = field_hint(
+            "Invalid field 'refs' on model 'res.partner'", "res.partner", PARTNER_FIELDS
+        )
+        assert "ref" in hint
+        assert "odoo://res.partner/fields" in hint
+
+    def test_hint_without_a_match_still_points_at_the_list(self):
+        hint = field_hint("Invalid field 'zzzzzzzz' on res.partner", "res.partner", PARTNER_FIELDS)
+        assert "odoo://res.partner/fields" in hint
+        assert str(len(PARTNER_FIELDS)) in hint
+
+    def test_not_a_field_error_gets_no_hint(self):
+        assert field_hint("Operation failed: Request-sent", "res.partner", PARTNER_FIELDS) is None
+
+
+class TestWithFieldHint:
+    def _getter(self, calls=None):
+        def getter(model):
+            if calls is not None:
+                calls.append(model)
+            return PARTNER_FIELDS
+
+        return getter
+
+    def test_enriches_a_field_error(self):
+        result = with_field_hint(
+            "Invalid field 'refs' on model 'res.partner'", "res.partner", "read", self._getter()
+        )
+        assert result.startswith("Invalid field 'refs'")
+        assert "Did you mean" in result
+
+    def test_fields_get_is_not_enriched(self):
+        """Guard against recursing into the very call that just failed."""
+        calls = []
+        message = "Invalid field 'refs' on model 'res.partner'"
+
+        result = with_field_hint(message, "res.partner", "fields_get", self._getter(calls))
+
+        assert result == message
+        assert calls == []
+
+    def test_other_errors_never_pay_for_a_lookup(self):
+        calls = []
+        message = "Operation failed: Request-sent"
+
+        result = with_field_hint(message, "res.partner", "search_count", self._getter(calls))
+
+        assert result == message
+        assert calls == []
+
+    def test_a_broken_lookup_returns_the_original_error(self):
+        """A diagnostic must never replace the error it describes."""
+        message = "Invalid field 'refs' on model 'res.partner'"
+
+        def boom(model):
+            raise RuntimeError("Odoo unreachable")
+
+        assert with_field_hint(message, "res.partner", "read", boom) == message
+
+
+class TestTransportIntegration:
+    def test_xmlrpc_fault_carries_the_hint(self):
+        import xmlrpc.client
+
+        from mcp_server_odoo.exceptions import OdooConnectionError
+        from mcp_server_odoo.odoo_connection.orm import OdooConnectionOrmMixin
+
+        class _Conn(OdooConnectionOrmMixin):
+            def __init__(self):
+                self._authenticated = True
+                self._connected = True
+                self._auth_method = "api_key"
+                self._database = "db"
+                self._uid = 1
+                self.config = MagicMock(api_key="k")
+                self.object_proxy = MagicMock()
+                self.object_proxy.execute_kw.side_effect = xmlrpc.client.Fault(
+                    1, "Invalid field 'refs' on model 'res.partner'"
+                )
+
+            def fields_get(self, model, attributes=None):
+                return {f: {} for f in PARTNER_FIELDS}
+
+        with pytest.raises(OdooConnectionError) as exc:
+            _Conn().execute_kw("res.partner", "read", [[1]], {})
+
+        assert "Did you mean" in str(exc.value)
+        assert "ref" in str(exc.value)


### PR DESCRIPTION
Fixes pantalytics/odoo-mcp-pro-admin#222.

## Waarom

Odoo antwoordt op een verkeerde veldnaam met de naam die hij weigerde en verder niets:

    Invalid field 'x_partner_ref' on model 'res.partner'

De AI weet dan dat zijn gok fout was, maar niet wat de alternatieven zijn. De volgende gok is dus net zo blind als de eerste. Dat is de grootste foutcategorie op de server. Uit de fingerprint-corpus op prod, gepromoveerde templates:

| methode | sightings | workspace-hits |
|---|---|---|
| `read` | 2.840 | 1.489 |
| `search_count` | 225 | 188 |
| `create` | 150 | 116 |
| `search_read` | 82 | 69 |
| overig | ~150 | ~120 |

`read` staat zo ver bovenaan omdat het de eerste stap van bijna elke flow is: één misser kost meteen een hele beurt.

## Wat er verandert

Nieuwe module `field_hints.py`, puur stringwerk. Beide transportlagen (XML-RPC en JSON/2) halen hun foutmelding er doorheen vlak voordat ze hem opgooien:

    Invalid field 'x_partner_ref' on model 'res.partner'
    Did you mean: ref, parent_id? Full list: odoo://res.partner/fields

Zonder bruikbare match wijst hij alsnog naar de lijst in plaats van een suggestie te verzinnen.

Drie dingen bewust zo gebouwd:

- **De veldenlijst wordt alleen op het foutpad opgehaald**, en pas nadat de melding herkend is als veldfout. Na de eerste misser per model komt hij uit de bestaande fields-cache, dus in de praktijk kost het niets.
- **`fields_get` is uitgesloten**, anders zou de hint recursief de call aanroepen die net faalde.
- **Best effort, altijd**. Een mislukte lookup geeft de originele foutmelding onaangeroerd terug. Een diagnose mag nooit de fout vervangen die hij beschrijft.

Bij een dotted pad (`partner_id.x_foo`) wordt alleen op de kop gematcht: de staart hoort bij een ander model, en een suggestie daarvoor zou naar de verkeerde kant wijzen.

## Tests

23 tests in `tests/test_field_hints.py`. De zeven Odoo-formuleringen komen uit de corpus, niet uit de documentatie: dezelfde weigering wordt afhankelijk van versie en codepad minstens vijf keer anders verwoord. Verder de recursie-guard, de kapotte-lookup-tak, en een end-to-end test dat een XML-RPC fault de hint daadwerkelijk meedraagt.

611 unit tests groen, ruff check en format schoon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)